### PR TITLE
Fix a incorrectly copy-pasted comment

### DIFF
--- a/code/src/main/orxMain.c
+++ b/code/src/main/orxMain.c
@@ -261,7 +261,7 @@ orxSTATUS orxFASTCALL orxMain_Run()
         /* Is F12 pressed? */
         if(orxKeyboard_IsKeyPressed(orxKEYBOARD_KEY_F12) != orxFALSE)
         {
-          /* Toggles vsync */
+          /* Captures a screenshot */
           orxScreenshot_Capture();
 
           /* Updates key status */


### PR DESCRIPTION
Looks like a copy-pasted section kept a comment from the above block. Fix the comment so that it indicates this block captures a screenshot.