### PR TITLE
Fixed postbuild for Xcode project

### DIFF
--- a/tutorial/build/premake4.lua
+++ b/tutorial/build/premake4.lua
@@ -233,7 +233,7 @@ project "01_Object"
 -- Mac OS X
 
     configuration {"macosx"}
-        postbuildcommands {"$(shell [ -f " .. copybase .. "/../code/lib/dynamic/liborx.dylib ] && cp -f " .. copybase .. "/../code/lib/dynamic/liborx*.dylib " .. copybase .. "/bin)"}
+        postbuildcommands {"$([ -f " .. copybase .. "/../code/lib/dynamic/liborx.dylib ] && cp -f " .. copybase .. "/../code/lib/dynamic/liborx*.dylib " .. copybase .. "/bin)"}
 
 
 -- Windows


### PR DESCRIPTION
Removed the `shell` command from the post-build options for the `01_Object` project.

Tested by deleting all the Xcode projects, re-running `setup.sh`, and recompiling Orx first, then `01_Object`.