### PR TITLE
- added _orxDebug_SetLogCallback and orxDEBUG_KU32_STATIC_FLAG_CALLBACK

### DIFF
--- a/code/include/debug/orxDebug.h
+++ b/code/include/debug/orxDebug.h
@@ -60,10 +60,11 @@
 #define orxDEBUG_KU32_STATIC_FLAG_FILE                0x00000010
 #define orxDEBUG_KU32_STATIC_FLAG_TERMINAL            0x00000020
 #define orxDEBUG_KU32_STATIC_FLAG_CONSOLE             0x00000040
+#define orxDEBUG_KU32_STATIC_FLAG_CALLBACK            0x00000080
 
 #define orxDEBUG_KU32_STATIC_MASK_DEFAULT             0x00000075
 
-#define orxDEBUG_KU32_STATIC_MASK_DEBUG               0x0000003D
+#define orxDEBUG_KU32_STATIC_MASK_DEBUG               0x000000BD
 
 #define orxDEBUG_KU32_STATIC_MASK_USER_ALL            0x0FFFFFFF
 
@@ -75,6 +76,8 @@
 #define orxDEBUG_KZ_DEFAULT_LOG_SUFFIX                ".log"
 #define orxDEBUG_KZ_DEFAULT_DEBUG_SUFFIX              "-debug.log"
 
+/* Log callback function */
+typedef void                              (orxFASTCALL *orxDEBUG_CALLBACK_FUNCTION) (const orxSTRING _zText);
 
 /* *** Debug Macros *** */
 
@@ -418,6 +421,11 @@ extern orxDLLAPI void orxFASTCALL             _orxDebug_SetDebugFile(const orxST
  * @param[in]   _zFileName                    Log file name
  */
 extern orxDLLAPI void orxFASTCALL             _orxDebug_SetLogFile(const orxSTRING _zFileName);
+
+/** Sets log callback function
+* @param[in]   _pfnCallback                   Pointer to log callback function
+*/
+extern orxDLLAPI void orxFASTCALL             _orxDebug_SetLogCallback(const orxDEBUG_CALLBACK_FUNCTION _pfnCallback);
 
 #endif /* __orxDEBUG_H_ */
 

--- a/code/src/debug/orxDebug.c
+++ b/code/src/debug/orxDebug.c
@@ -104,6 +104,9 @@ typedef struct __orxDEBUG_STATIC_t
   /* Control flags */
   orxU32 u32Flags;
 
+  /* Callback function pointer */
+  orxDEBUG_CALLBACK_FUNCTION pfnCallback;
+
 } orxDEBUG_STATIC;
 
 
@@ -395,6 +398,10 @@ void orxFASTCALL _orxDebug_Exit()
     {
        fclose(sstDebug.pstDebugFile);
        sstDebug.pstDebugFile = orxNULL;
+    }
+    if(sstDebug.pfnCallback != orxNULL)
+    {
+       sstDebug.pfnCallback = orxNULL;
     }
 
 #endif /* !__orxANDROID__ && !__orxANDROID_NATIVE__ */
@@ -717,6 +724,18 @@ void orxCDECL _orxDebug_Log(orxDEBUG_LEVEL _eLevel, const orxSTRING _zFunction, 
         orxConsole_Log(zBuffer);
       }
     }
+
+    /* Callback configured? */
+    if(sstDebug.u32DebugFlags & orxDEBUG_KU32_STATIC_FLAG_CALLBACK)
+    {
+      /* Is the pointer valid? */
+      if(sstDebug.pfnCallback != orxNULL)
+      {
+        /* Logs it */
+        sstDebug.pfnCallback(zBuffer);
+      }
+    }
+
   }
 
   /* Done */
@@ -885,6 +904,19 @@ void orxFASTCALL _orxDebug_SetLogFile(const orxSTRING _zFileName)
     sstDebug.zLogFile = (orxSTRING)orxDEBUG_KZ_DEFAULT_LOG_FILE;
   }
 }
+
+/** Sets log callback function
+* @param[in]   _pfnCallback                   Pointer to log callback function
+*/
+void orxFASTCALL _orxDebug_SetLogCallback(const orxDEBUG_CALLBACK_FUNCTION _pfnCallback)
+{
+  /* Checks */
+  orxASSERT(sstDebug.u32Flags & orxDEBUG_KU32_STATIC_FLAG_READY);
+
+  /* Just set the callback */
+  sstDebug.pfnCallback = _pfnCallback;
+}
+
 
 #ifdef __orxMSVC__
 


### PR DESCRIPTION
Compiled and tested.
The user is needed to call _orxDebug_SetLogCallback and then to set orxDEBUG_KU32_STATIC_FLAG_CALLBACK using _orxDebug_SetFlags in order to let orx to call the configured callback.