### PR TITLE
Fix missing pipe in orxLOG_CONSOLE

### DIFF
--- a/code/include/debug/orxDebug.h
+++ b/code/include/debug/orxDebug.h
@@ -164,7 +164,7 @@ typedef orxSTATUS (orxFASTCALL *orxDEBUG_CALLBACK_FUNCTION)(orxDEBUG_LEVEL _eLev
     u32DebugFlags = _orxDebug_GetFlags();                                                                         \
     _orxDebug_SetFlags(orxDEBUG_KU32_STATIC_FLAG_CONSOLE,                                                         \
                        orxDEBUG_KU32_STATIC_FLAG_FILE                                                             \
-                       orxDEBUG_KU32_STATIC_FLAG_TERMINAL);                                                       \
+                      |orxDEBUG_KU32_STATIC_FLAG_TERMINAL);                                                       \
     _orxDebug_Log(orxDEBUG_LEVEL_LOG, (const orxSTRING)__FUNCTION__, __FILE__, __LINE__, STRING, ##__VA_ARGS__);  \
     _orxDebug_SetFlags(u32DebugFlags, orxDEBUG_KU32_STATIC_MASK_USER_ALL);                                        \
   } while(orxFALSE)
@@ -209,7 +209,7 @@ typedef orxSTATUS (orxFASTCALL *orxDEBUG_CALLBACK_FUNCTION)(orxDEBUG_LEVEL _eLev
       u32DebugFlags = _orxDebug_GetFlags();                                                                       \
       _orxDebug_SetFlags(orxDEBUG_KU32_STATIC_FLAG_CONSOLE,                                                       \
                          orxDEBUG_KU32_STATIC_FLAG_FILE                                                           \
-                         orxDEBUG_KU32_STATIC_FLAG_TERMINAL);                                                     \
+                        |orxDEBUG_KU32_STATIC_FLAG_TERMINAL);                                                     \
       _orxDebug_Log(orxDEBUG_LEVEL_LOG, (const orxSTRING)__FUNCTION__, __FILE__, __LINE__, STRING, __VA_ARGS__);  \
       _orxDebug_SetFlags(u32DebugFlags, orxDEBUG_KU32_STATIC_MASK_USER_ALL);                                      \
     } while(orxFALSE)


### PR DESCRIPTION
This updates `orxLOG_CONSOLE` to match the other `orxLOG_*` macros.