### PR TITLE
Fixed a bug where touch input stopped working.

### DIFF
--- a/code/src/main/orxAndroidNativeSupport.cpp
+++ b/code/src/main/orxAndroidNativeSupport.cpp
@@ -260,6 +260,7 @@ static int32_t handleInput(struct android_app* app, AInputEvent* event)
                 orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_BEGIN, orxNULL, orxNULL, &stPayload);
                 break;
             case AMOTION_EVENT_ACTION_UP:
+            case AMOTION_EVENT_ACTION_CANCEL:
                 stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orx2F(AMotionEvent_getX(event, 0));
                 stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orx2F(AMotionEvent_getY(event, 0));
                 stPayload.stTouch.u32ID = AMotionEvent_getPointerId(event, 0);

--- a/code/src/main/orxAndroidSupport.cpp
+++ b/code/src/main/orxAndroidSupport.cpp
@@ -805,6 +805,7 @@ extern "C" void orxAndroid_PumpEvents()
           orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_BEGIN, orxNULL, orxNULL, &stPayload);
           break;
         case 1: // MotionEvent.ACTION_UP
+        case 3: // MotionEvent.ACTION_CANCEL
         case 6: // MotionEvent.ACTION_POINTER_UP
           orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_END, orxNULL, orxNULL, &stPayload);
           break;


### PR DESCRIPTION
A "down" touch event does not necessarily end with an "up" event. This is particularly easy to demonstrate on modern Android devices where go *Home* using a gesture. Performing such an operation effectively disables any touch down events when resuming the app. Not so nice.