### PR TITLE
Fixed lint errors in build for Android demos.

### DIFF
--- a/code/build/android/java/org/orx/lib/OrxActivity.java
+++ b/code/build/android/java/org/orx/lib/OrxActivity.java
@@ -38,7 +38,7 @@ public class OrxActivity extends FragmentActivity implements SurfaceHolder.Callb
 
     @Override
     protected void onCreate(Bundle arg0) {
-    	super.onCreate(arg0);
+    	  super.onCreate(arg0);
 
         nativeOnCreate();
         mInputManager = InputManagerCompat.Factory.getInputManager(this);
@@ -52,6 +52,7 @@ public class OrxActivity extends FragmentActivity implements SurfaceHolder.Callb
     }
 
     @Override
+    @SuppressLint("ClickableViewAccessibility")
     protected void onStart() {
     	super.onStart();
 
@@ -74,16 +75,13 @@ public class OrxActivity extends FragmentActivity implements SurfaceHolder.Callb
                 setContentView(mSurface);
             }
 
-        	mSurface.getHolder().addCallback(this);
-        	mSurface.setFocusable(true);
-        	mSurface.setFocusableInTouchMode(true);
-        	mSurface.setOnKeyListener(this);
-        	mSurface.setOnTouchListener(this);
-
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
-                mSurface.setOnGenericMotionListener(new OrxOnGenericMotionListener(this, mInputManager));
-            }
-    	}
+            mSurface.getHolder().addCallback(this);
+            mSurface.setFocusable(true);
+            mSurface.setFocusableInTouchMode(true);
+            mSurface.setOnKeyListener(this);
+            mSurface.setOnTouchListener(this);
+            mSurface.setOnGenericMotionListener(new OrxOnGenericMotionListener(this, mInputManager));
+    	  }
 
         if(!mRunning.getAndSet(true)) {
             mOrxThread.start();
@@ -236,7 +234,8 @@ public class OrxActivity extends FragmentActivity implements SurfaceHolder.Callb
     }
 
     // Touch events
-	public boolean onTouch(View v, MotionEvent event) {
+    @SuppressLint("ClickableViewAccessibility")
+  	public boolean onTouch(View v, MotionEvent event) {
         final int touchDevId = event.getDeviceId();
         final int pointerCount = event.getPointerCount();
         // touchId, pointerId, action, x, y, pressure

--- a/code/demo/android-native/app/src/main/AndroidManifest.xml
+++ b/code/demo/android-native/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-feature android:glEsVersion="0x00020000"/>
 
-    <application android:allowBackup="true"
+    <application android:allowBackup="false"
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
         android:theme="@style/AppTheme">
@@ -13,7 +13,7 @@
              This will take care of integrating with our NDK code. -->
         <activity android:name=".MainActivity"
             android:label="@string/app_name"
-            android:screenOrientation="sensorPortrait"
+            android:screenOrientation="fullSensor"
             android:configChanges="orientation|keyboardHidden|screenSize">
 
             <!-- Tell activity the name of our .so -->

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -5,6 +5,8 @@ def orx = System.getenv('ORX') ?: "../../.."
 android {
   compileSdkVersion sdkVersion.toInteger()
 
+  // NDK: https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
+  // Verify result of ndk_locator in android/app/.cxx/ndk_locator_record_*.log
   ndkVersion "21.3.6528147"
 
   defaultConfig {
@@ -66,7 +68,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'androidx.fragment:fragment:1.2.5'
+  implementation 'androidx.fragment:fragment:1.3.1'
 
   implementation fileTree(include: ['*.jar'], dir: 'libs')
 }

--- a/code/demo/android/app/src/main/AndroidManifest.xml
+++ b/code/demo/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.orxproject.orxtest">
 
-    <application android:allowBackup="true"
+    <application android:allowBackup="false"
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
         android:theme="@style/AppTheme"
@@ -10,7 +10,7 @@
         <activity android:name="org.orxproject.orxtest.OrxDemo" android:label="@string/app_name"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:launchMode="singleTask"
-            android:screenOrientation="sensorPortrait">
+            android:screenOrientation="fullSensor">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/code/demo/android/app/src/main/res/values-v14/themes.xml
+++ b/code/demo/android/app/src/main/res/values-v14/themes.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="MyTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen"/>
-</resources>


### PR DESCRIPTION
Fixed lint errors in android demo builds; both android and android-native, which causes build to fail because we want warnings to be treated as errors (see build.gradle lintOptions.warningsAsErrors).

Some references:
https://developer.android.com/guide/topics/data/autobackup
https://stackoverflow.com/questions/47107105/android-button-has-setontouchlistener-called-on-it-but-does-not-override-perform

My builds lint errors for demo/android:

_warning: ObsoleteLintCustomCheck: Obsolete custom lint check
Lint found an issue registry (androidx.fragment.lint.FragmentIssueRegistry) which is older than the current API level; these checks may not work correctly.
Recompile the checks against the latest version. Custom check API version is 6 (3.6), current lint API level is 8 (4.1+)

error: GradleDependency: Obsolete Gradle Dependency
../../build.gradle:69: A newer version of androidx.fragment:fragment than 1.2.5 is available: 1.3.1

error: LockedOrientationActivity: Incompatible screenOrientation value
../../src/main/AndroidManifest.xml:13: Expecting android:screenOrientation="unspecified" or "fullSensor" for this activity so the user can use the application in any orientation and provide a great experience on Chrome OS devices

error: AllowBackup: AllowBackup/FullBackupContent Problems
../../src/main/AndroidManifest.xml:4: On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute android:fullBackupContent to specify an @xml resource which configures which files to backup. More info: https://developer.android.com/training/backup/autosyncapi.html

error: ObsoleteSdkInt: Obsolete SDK_INT Version Check
../../src/main/res/values-v14: This folder configuration (v14) is unnecessary; minSdkVersion is 17. Merge all the resources in this folder into values.

error: UnusedResources: Unused resources
../../src/main/res/values-v14/themes.xml:3: The resource R.style.MyTheme appears to be unused

error: ClickableViewAccessibility: Accessibility in Custom Views
../../../../../build/android/java/org/orx/lib/OrxActivity.java:85: Custom view SurfaceView has setOnTouchListener called on it but does not override performClick
../../../../../build/android/java/org/orx/lib/OrxActivity.java:238: OrxActivity#onTouch should call View#performClick when a click is detected

I have reverted this so we see these and fix these. Build now fails:

Task :app:lint
Ran lint on variant debug: 8 issues found
Ran lint on variant release: 7 issues found_
