### PR TITLE
Add basic setup and build tasks for VS Code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,62 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Setup orx",
+            "group": "build",
+            "type": "shell",
+            "command": "./setup.sh",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "windows": {
+                "command": ".\\setup.bat",
+                "options": {
+                    "shell": {
+                        "executable": "cmd.exe",
+                        "args": [
+                            "/d",
+                            "/c"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "label": "Build orx (debug)",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "type": "shell",
+            "linux": {
+                "command": "make",
+                "options": {
+                    "cwd": "code/build/linux/gmake/"
+                }
+            },
+            "osx": {
+                "command": "make",
+                "options": {
+                    "cwd": "code/build/mac/gmake/"
+                }
+            },
+            "windows": {
+                "command": "mingw32-make.exe",
+                "options": {
+                    "cwd": "code/build/windows/gmake/",
+                    "shell": {
+                        "executable": "cmd.exe",
+                        "args": [
+                            "/d",
+                            "/c"
+                        ]
+                    }
+                }
+            },
+            "problemMatcher": [
+                "$gcc"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds two tasks to VS Code:
- Setup orx
- Build orx (debug)

It's only been tested on macOS so far. I should be able to test Linux and Windows in the next few days. I wanted to push this out so that it's readily accessible and testable in case anyone else wants to give it a try!