### PR TITLE
Swappy improvements + improved key filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,11 +85,6 @@ matrix:
       android:
         components:
           - build-tools-29.0.3
-      before_install:
-        - touch $HOME/.android/repositories.cfg
-        - wget "https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip" -O commandlinetools.zip
-        - unzip commandlinetools.zip -d $ANDROID_HOME
-        - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --install "ndk;23.1.7779620" --sdk_root=$ANDROID_HOME
       install:
         - ./setup.sh
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: c++
 
-matrix:
+jobs:
   include:
     - os: linux
       compiler: gcc
-      sudo: required
       script: ./code/build/travis/desktop.sh
       name: Linux / GCC
 
     - os: linux
       compiler: clang
-      sudo: required
       script: ./code/build/travis/desktop.sh
       name: Linux / Clang
 
@@ -85,6 +83,10 @@ matrix:
       android:
         components:
           - build-tools-29.0.3
+      before_install:
+        - sudo mkdir -p /usr/local/android-sdk/licenses/
+        - sudo touch /usr/local/android-sdk/licenses/android-sdk-license
+        - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" | sudo tee -a /usr/local/android-sdk/licenses/android-sdk-license
       install:
         - ./setup.sh
       before_script:

--- a/code/build/android/gradle.properties
+++ b/code/build/android/gradle.properties
@@ -20,4 +20,11 @@ android.useAndroidX=true
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
+# Specifies the target SDK version, which should always be the latest version available.
+# When bumped, be sure to re-visit the NDK version setting.
 sdkVersion=33
+
+# Specifies the NDK version to use. If not specified, command-line build fails.
+# Depends on SDK version. More details, visit
+# https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
+ndkVersion=23.1.7779620

--- a/code/build/android/gradle.properties
+++ b/code/build/android/gradle.properties
@@ -21,10 +21,4 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 
 # Specifies the target SDK version, which should always be the latest version available.
-# When bumped, be sure to re-visit the NDK version setting.
 sdkVersion=33
-
-# Specifies the NDK version to use. If not specified, command-line build fails.
-# Depends on SDK version. More details, visit
-# https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
-ndkVersion=23.1.7779620

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -6,6 +6,7 @@ plugins {
 android {
     namespace 'org.orx.lib'
     compileSdk sdkVersion.toInteger()
+    ndkVersion ndkVersion
 
     buildFeatures {
         prefab true
@@ -69,7 +70,7 @@ android {
 
             externalNativeBuild.ndkBuild {
                 arguments 'NDK_DEBUG=0'
-                cFlags '-D__orxPROFILE__'
+                cFlags '-D__orxPROFILER__'
             }
         }
     }

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -6,8 +6,7 @@ plugins {
 android {
     namespace 'org.orx.lib'
     compileSdk sdkVersion.toInteger()
-    ndkVersion ndkVersion
-
+    
     buildFeatures {
         prefab true
         prefabPublishing true
@@ -38,10 +37,7 @@ android {
         liquidfun_static {
             headers "${System.env.ORX}/../extern/LiquidFun-1.1.0/include"
         }
-        // We prefab the NDK cpufeatures module (legacy), until prefab/cpu_features is released.
-        // See https://github.com/google/prefab/issues/93
         cpufeatures {
-            headers "${ndkDirectory}/sources/android/cpufeatures"
         }
     }
     packagingOptions {
@@ -82,9 +78,9 @@ dependencies {
     api 'androidx.core:core:1.9.0'
     api 'androidx.appcompat:appcompat:1.6.1'
 
-    api 'androidx.games:games-activity:2.0.0-rc01'
-    api 'androidx.games:games-controller:2.0.0-rc01'
-    api 'androidx.games:games-frame-pacing:2.0.0-rc01'
+    api 'androidx.games:games-activity:2.0.0'
+    api 'androidx.games:games-controller:2.0.0'
+    api 'androidx.games:games-frame-pacing:2.0.0'
 }
 
 afterEvaluate {

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdk 19
         targetSdk sdkVersion.toInteger()
         versionCode 113
-        versionName "1.13"
+        versionName '1.13'
     }
     externalNativeBuild {
         ndkBuild {
@@ -41,7 +41,7 @@ android {
         }
     }
     packagingOptions {
-        exclude("**/libc++_shared.so")
+        exclude('**/libc++_shared.so')
     }
     buildTypes {
         release {
@@ -122,7 +122,7 @@ androidComponents {
                 // See this FR: https://issuetracker.google.com/issues/214034366
                 task.doLast {
                     copy {
-                        from ("./src/main/prefab")
+                        from ('./src/main/prefab')
                         into ("./build/intermediates/prefab_package/${variant.name}/prefab")
                         include '**/*.json'
                     }

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     api 'androidx.core:core:1.9.0'
     api 'androidx.appcompat:appcompat:1.6.1'
 
-    api 'androidx.games:games-activity:2.0.0'
+    api 'androidx.games:games-activity:2.0.1'
     api 'androidx.games:games-controller:2.0.0'
     api 'androidx.games:games-frame-pacing:2.0.0'
 }

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -3,8 +3,7 @@ apply plugin: 'com.android.application'
 android {
     namespace 'org.orx.demo'
     compileSdk sdkVersion.toInteger()
-    ndkVersion ndkVersion
-
+    
     buildFeatures.prefab true
 
     defaultConfig {

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -7,17 +7,13 @@ android {
     buildFeatures.prefab true
 
     defaultConfig {
-        applicationId "org.orx.demo"
+        applicationId 'org.orx.demo'
         targetSdkVersion sdkVersion.toInteger()
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
 
         minSdkVersion 19
         vectorDrawables.useSupportLibrary = true
-
-        ndk {
-            abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
-        }
 
         manifestPlaceholders = [ gameArguments: '' ]
     }

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     namespace 'org.orx.demo'
     compileSdk sdkVersion.toInteger()
+    ndkVersion ndkVersion
 
     buildFeatures.prefab true
 
@@ -62,7 +63,7 @@ android {
 
             externalNativeBuild.ndkBuild {
                 arguments 'NDK_DEBUG=0'
-                cFlags '-D__orxPROFILE__'
+                cFlags '-D__orxPROFILER__'
             }
             manifestPlaceholders = [ gameArguments: 'orxDemoProfile' ]
         }

--- a/code/demo/android/app/src/main/AndroidManifest.xml
+++ b/code/demo/android/app/src/main/AndroidManifest.xml
@@ -7,14 +7,14 @@
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@drawable/ic_launcher_round"
-        android:theme="@style/Application.Fullscreen">
+        android:theme="@style/Application.Fullscreen"
+        android:appCategory="game">
 
         <activity android:name="org.orx.lib.OrxGameActivity"
             android:label="@string/app_name"
             android:screenOrientation="fullSensor"
             android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize"
             android:resizeableActivity="true"
-            android:appCategory="game"
             android:exported="true">
 
             <meta-data android:name="android.app.lib_name" android:value="orxDemo" />

--- a/code/demo/android/app/src/main/AndroidManifest.xml
+++ b/code/demo/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         <activity android:name="org.orx.lib.OrxGameActivity"
             android:label="@string/app_name"
             android:screenOrientation="fullSensor"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="orientation|keyboardHidden|screenSize|screenLayout|smallestScreenSize"
+            android:resizeableActivity="true"
             android:appCategory="game"
             android:exported="true">
 

--- a/code/demo/android/app/src/main/AndroidManifest.xml
+++ b/code/demo/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
             android:label="@string/app_name"
             android:screenOrientation="fullSensor"
             android:configChanges="orientation|keyboardHidden|screenSize"
+            android:appCategory="game"
             android:exported="true">
 
             <meta-data android:name="android.app.lib_name" android:value="orxDemo" />

--- a/code/demo/android/app/src/main/assets/orxDemoProfile.ini
+++ b/code/demo/android/app/src/main/assets/orxDemoProfile.ini
@@ -7,4 +7,11 @@
 Title = Orx Demo (profile)
 
 [Render]
-ShowProfiler = true
+ShowFPS         = true
+ShowProfiler    = true
+
+[-=RenderSet=-]
+JOY_A_1      = ProfilerToggleHistory
+JOY_START_1  = ProfilerPause
+JOY_LEFT_1   = ProfilerPreviousFrame
+JOY_RIGHT_1  = ProfilerNextFrame

--- a/code/demo/android/app/src/main/res/values/colors.xml
+++ b/code/demo/android/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <color name="icon_foreground">#000000</color>
-  <color name="icon_background">#ffffff</color>
+  <color name="icon_background">#ffa600</color>
 </resources>

--- a/code/demo/android/build.bat
+++ b/code/demo/android/build.bat
@@ -1,0 +1,1 @@
+gradlew clean assemble

--- a/code/demo/android/build.sh
+++ b/code/demo/android/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./gradlew clean assemble
+
+exit 0

--- a/code/demo/android/gradle.properties
+++ b/code/demo/android/gradle.properties
@@ -23,13 +23,7 @@
 android.useAndroidX=true
 
 # Specifies the target SDK version, which should always be the latest version available.
-# When bumped, be sure to re-visit the NDK version setting.
 sdkVersion=33
-
-# Specifies the NDK version to use. If not specified, command-line build fails.
-# Depends on SDK version. More details, visit
-# https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
-ndkVersion=23.1.7779620
 
 # Use R8 instead of ProGuard for code shrinking.
 android.enableR8.fullMode=true

--- a/code/demo/android/gradle.properties
+++ b/code/demo/android/gradle.properties
@@ -17,9 +17,19 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+
+# Specifies the target SDK version, which should always be the latest version available.
+# When bumped, be sure to re-visit the NDK version setting.
 sdkVersion=33
 
-android.useAndroidX=true
+# Specifies the NDK version to use. If not specified, command-line build fails.
+# Depends on SDK version. More details, visit
+# https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
+ndkVersion=23.1.7779620
 
 # Use R8 instead of ProGuard for code shrinking.
 android.enableR8.fullMode=true

--- a/code/include/main/android/orxAndroid.h
+++ b/code/include/main/android/orxAndroid.h
@@ -49,8 +49,6 @@
 #define KZ_CONFIG_ANDROID                        "Android"
 #define KZ_CONFIG_SURFACE_SCALE                  "SurfaceScale"
 #define KZ_CONFIG_ACCELEROMETER_FREQUENCY        "AccelerometerFrequency"
-#define KZ_CONFIG_AUTO_SWAP_INTERVAL             "AutoSwapInterval"
-#define KZ_CONFIG_AUTO_PIPELINE_MODE             "AutoPipelineMode"
 
 #include <android/native_window.h>
 

--- a/code/include/main/android/orxAndroid.h
+++ b/code/include/main/android/orxAndroid.h
@@ -49,6 +49,8 @@
 #define KZ_CONFIG_ANDROID                        "Android"
 #define KZ_CONFIG_SURFACE_SCALE                  "SurfaceScale"
 #define KZ_CONFIG_ACCELEROMETER_FREQUENCY        "AccelerometerFrequency"
+#define KZ_CONFIG_AUTO_SWAP_INTERVAL             "AutoSwapInterval"
+#define KZ_CONFIG_AUTO_PIPELINE_MODE             "AutoPipelineMode"
 
 #include <android/native_window.h>
 

--- a/code/include/main/android/orxAndroidActivity.h
+++ b/code/include/main/android/orxAndroidActivity.h
@@ -61,6 +61,11 @@ extern "C"
   */
 GameActivity *orxAndroid_GetGameActivity();
 
+/**
+  Set key filter callback
+  */
+void orxAndroid_SetKeyFilter(android_key_event_filter filter);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/code/include/orx.h
+++ b/code/include/orx.h
@@ -216,8 +216,6 @@ static orxINLINE void orx_Execute(orxU32 _u32NbParams, orxSTRING _azParams[], co
           bStop == orxFALSE;
           bStop = ((sbStopByEvent != orxFALSE) || (eMainStatus == orxSTATUS_FAILURE) || (eClockStatus == orxSTATUS_FAILURE)) ? orxTRUE : orxFALSE)
       {
-        orxAndroid_PumpEvents();
-
         /* Sends frame start event */
         orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_GAME_LOOP_START, orxNULL, orxNULL, &stPayload);
 

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -4367,12 +4367,6 @@ orxSTATUS orxFASTCALL orxDisplay_Android_Init()
       /* Pops config section */
       orxConfig_PopSection();
       
-      /* Pushes Android section */
-      orxConfig_PushSection(KZ_CONFIG_ANDROID);
-      
-      /* Pops Android section */
-      orxConfig_PopSection();
-      
       /* Gets max texture unit number */
       glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &(sstDisplay.iTextureUnitNumber));
       glASSERT();

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -3874,7 +3874,7 @@ orxDISPLAY_VIDEO_MODE *orxFASTCALL orxDisplay_Android_GetVideoMode(orxU32 _u32In
   _pstVideoMode->u32Width       = orxF2U(sstDisplay.pstScreen->fWidth);
   _pstVideoMode->u32Height      = orxF2U(sstDisplay.pstScreen->fHeight);
   _pstVideoMode->u32Depth       = sstDisplay.u32Depth;
-  _pstVideoMode->u32RefreshRate = 60;
+  _pstVideoMode->u32RefreshRate = sstDisplay.u32RefreshRate;
   _pstVideoMode->bFullScreen    = orxTRUE;
 
   /* Updates result */
@@ -3906,7 +3906,7 @@ orxSTATUS orxFASTCALL orxDisplay_Android_SetVideoMode(const orxDISPLAY_VIDEO_MOD
 
     if( eResult == orxSTATUS_SUCCESS )
     {
-      int iDepth;
+      int iDepth, iRefreshRate;
 
       /* Gets its info */
       eglQuerySurface(sstDisplay.display, sstDisplay.surface, EGL_WIDTH, &iWidth);
@@ -3914,6 +3914,7 @@ orxSTATUS orxFASTCALL orxDisplay_Android_SetVideoMode(const orxDISPLAY_VIDEO_MOD
       eglQuerySurface(sstDisplay.display, sstDisplay.surface, EGL_HEIGHT, &iHeight);
       eglASSERT();
       iDepth        = (int)_pstVideoMode->u32Depth;
+      iRefreshRate  = (int)_pstVideoMode->u32RefreshRate;
 
       orxDISPLAY_EVENT_PAYLOAD stPayload;
 
@@ -3922,7 +3923,7 @@ orxSTATUS orxFASTCALL orxDisplay_Android_SetVideoMode(const orxDISPLAY_VIDEO_MOD
       stPayload.stVideoMode.u32Width                = (orxU32)iWidth;
       stPayload.stVideoMode.u32Height               = (orxU32)iHeight;
       stPayload.stVideoMode.u32Depth                = (orxU32)iDepth;
-      stPayload.stVideoMode.u32RefreshRate          = sstDisplay.u32RefreshRate;
+      stPayload.stVideoMode.u32RefreshRate          = (orxU32)iRefreshRate;
       stPayload.stVideoMode.u32PreviousWidth        = orxF2U(sstDisplay.pstScreen->fWidth);
       stPayload.stVideoMode.u32PreviousHeight       = orxF2U(sstDisplay.pstScreen->fHeight);
       stPayload.stVideoMode.u32PreviousDepth        = sstDisplay.pstScreen->u32Depth;
@@ -3969,6 +3970,7 @@ orxSTATUS orxFASTCALL orxDisplay_Android_SetVideoMode(const orxDISPLAY_VIDEO_MOD
 
       /* Stores screen depth & refresh rate */
       sstDisplay.u32Depth       = (orxU32)iDepth;
+      sstDisplay.u32RefreshRate = (orxU32)iRefreshRate;
 
       /* Sends event */
       orxEVENT_SEND(orxEVENT_TYPE_DISPLAY, orxDISPLAY_EVENT_SET_VIDEO_MODE, orxNULL, orxNULL, &stPayload);

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -4211,7 +4211,8 @@ orxSTATUS orxFASTCALL orxDisplay_Android_Init()
       const orxSTRING zGlRenderer;
       const orxSTRING zGlVersion;
       int32_t width, height;
-
+      orxBOOL bAutoSwapInterval, bAutoPipelineMode;
+      
       /* Pushes display section */
       orxConfig_PushSection(orxDISPLAY_KZ_CONFIG_SECTION);
 
@@ -4226,7 +4227,7 @@ orxSTATUS orxFASTCALL orxDisplay_Android_Init()
         sstDisplay.u32Flags = orxDISPLAY_KU32_STATIC_FLAG_NONE;
       }
 
-      sstDisplay.u32Depth = orxConfig_HasValue(orxDISPLAY_KZ_CONFIG_DEPTH) ? orxConfig_GetU32(orxDISPLAY_KZ_CONFIG_DEPTH) : 24;
+      sstDisplay.u32Depth = orxConfig_HasValue(orxDISPLAY_KZ_CONFIG_DEPTH) ? orxConfig_GetU32(orxDISPLAY_KZ_CONFIG_DEPTH) : 32;
       sstDisplay.u32RefreshRate = 60;
       
       /* Create OpenGL ES Context */
@@ -4285,7 +4286,22 @@ orxSTATUS orxFASTCALL orxDisplay_Android_Init()
 
       /* Pops config section */
       orxConfig_PopSection();
-
+      
+      /* Pushes Android section */
+      orxConfig_PushSection(KZ_CONFIG_ANDROID);
+      
+      bAutoSwapInterval = orxConfig_GetBool(KZ_CONFIG_AUTO_SWAP_INTERVAL);
+      bAutoPipelineMode = orxConfig_GetBool(KZ_CONFIG_AUTO_PIPELINE_MODE);
+      /* Pops Android section */
+      orxConfig_PopSection();
+      
+      /* Sets auto-swap interval and auto-pipeline mode */
+      SwappyGL_setAutoSwapInterval(bAutoSwapInterval);
+      SwappyGL_setAutoPipelineMode(bAutoPipelineMode);
+      
+      /* Sets or hints (if auto-swapping) at 60 Hz */
+      SwappyGL_setSwapIntervalNS(SWAPPY_SWAP_60FPS);
+      
       /* Gets max texture unit number */
       glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &(sstDisplay.iTextureUnitNumber));
       glASSERT();

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -3969,7 +3969,6 @@ orxSTATUS orxFASTCALL orxDisplay_Android_SetVideoMode(const orxDISPLAY_VIDEO_MOD
 
       /* Stores screen depth & refresh rate */
       sstDisplay.u32Depth       = (orxU32)iDepth;
-      sstDisplay.u32RefreshRate = 60;
 
       /* Sends event */
       orxEVENT_SEND(orxEVENT_TYPE_DISPLAY, orxDISPLAY_EVENT_SET_VIDEO_MODE, orxNULL, orxNULL, &stPayload);

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -508,6 +508,19 @@ static EGLConfig defaultEGLChooser(EGLDisplay disp)
  */
 static orxSTATUS orxFASTCALL orxDisplay_Android_RenderInhibitor(const orxEVENT *_pstEvent)
 {
+  /* Render stop? */
+  if(_pstEvent->eID == orxRENDER_EVENT_STOP)
+  {
+    /* Profiles */
+    orxPROFILER_PUSH_MARKER("PollEvents");
+
+    /* Polls events */
+    orxAndroid_PumpEvents();
+
+    /* Profiles */
+    orxPROFILER_POP_MARKER();
+  }
+
   /* Done! */
   return orxSTATUS_FAILURE;
 }
@@ -4105,6 +4118,15 @@ static orxSTATUS orxFASTCALL orxDisplay_Android_EventHandler(const orxEVENT *_ps
   {
     /* Draws remaining items */
     orxDisplay_Android_DrawArrays();
+    
+    /* Profiles */
+    orxPROFILER_PUSH_MARKER("PollEvents");
+
+    /* Polls events */
+    orxAndroid_PumpEvents();
+
+    /* Profiles */
+    orxPROFILER_POP_MARKER();
   }
 
   if(_pstEvent->eType == orxANDROID_EVENT_TYPE_SURFACE && _pstEvent->eID == orxANDROID_EVENT_SURFACE_DESTROYED)

--- a/code/plugins/Keyboard/android/orxKeyboard.cpp
+++ b/code/plugins/Keyboard/android/orxKeyboard.cpp
@@ -122,92 +122,94 @@ static orxKEYBOARD_KEY orxFASTCALL orxKeyboard_Android_GetKey(orxU32 _eKey)
   /* Depending on key */
   switch(_eKey)
   {
-    case AKEYCODE_BACK:               {eResult = orxKEYBOARD_KEY_ESCAPE; break;}
-    case AKEYCODE_SPACE:              {eResult = orxKEYBOARD_KEY_SPACE; break;}
-    case AKEYCODE_ENTER:              {eResult = orxKEYBOARD_KEY_ENTER; break;}
-    case AKEYCODE_BUTTON_SELECT:      {eResult = orxKEYBOARD_KEY_ENTER; break;}
-    case AKEYCODE_DEL:                {eResult = orxKEYBOARD_KEY_BACKSPACE; break;}
-    case AKEYCODE_TAB:                {eResult = orxKEYBOARD_KEY_TAB; break;}
-    case AKEYCODE_PAGE_UP:            {eResult = orxKEYBOARD_KEY_PAGE_UP; break;}
-    case AKEYCODE_PAGE_DOWN:          {eResult = orxKEYBOARD_KEY_PAGE_DOWN; break;}
-    case AKEYCODE_PLUS:               {eResult = orxKEYBOARD_KEY_NUMPAD_ADD; break;}
-    case AKEYCODE_STAR:               {eResult = orxKEYBOARD_KEY_NUMPAD_MULTIPLY; break;}
-    case AKEYCODE_MEDIA_PLAY_PAUSE:   {eResult = orxKEYBOARD_KEY_PAUSE; break;}
-    case AKEYCODE_ALT_RIGHT:          {eResult = orxKEYBOARD_KEY_RALT; break;}
-    case AKEYCODE_SHIFT_RIGHT:        {eResult = orxKEYBOARD_KEY_RSHIFT; break;}
-    case AKEYCODE_ALT_LEFT:           {eResult = orxKEYBOARD_KEY_LALT; break;}
-    case AKEYCODE_SHIFT_LEFT:         {eResult = orxKEYBOARD_KEY_LSHIFT; break;}
-    case AKEYCODE_MENU:               {eResult = orxKEYBOARD_KEY_MENU; break;}
-    case AKEYCODE_LEFT_BRACKET:       {eResult = orxKEYBOARD_KEY_LBRACKET; break;}
-    case AKEYCODE_RIGHT_BRACKET:      {eResult = orxKEYBOARD_KEY_RBRACKET; break;}
-    case AKEYCODE_SEMICOLON:          {eResult = orxKEYBOARD_KEY_SEMICOLON; break;}
-    case AKEYCODE_COMMA:              {eResult = orxKEYBOARD_KEY_COMMA; break;}
-    case AKEYCODE_PERIOD:             {eResult = orxKEYBOARD_KEY_PERIOD; break;}
-    case AKEYCODE_APOSTROPHE:         {eResult = orxKEYBOARD_KEY_QUOTE; break;}
-    case AKEYCODE_SLASH:              {eResult = orxKEYBOARD_KEY_SLASH; break;}
-    case AKEYCODE_BACKSLASH:          {eResult = orxKEYBOARD_KEY_BACKSLASH; break;}
-    case AKEYCODE_EQUALS:             {eResult = orxKEYBOARD_KEY_EQUAL; break;}
-    case AKEYCODE_MINUS:              {eResult = orxKEYBOARD_KEY_DASH; break;}
-    case AKEYCODE_DPAD_UP:            {eResult = orxKEYBOARD_KEY_UP; break;}
-    case AKEYCODE_DPAD_RIGHT:         {eResult = orxKEYBOARD_KEY_RIGHT; break;}
-    case AKEYCODE_DPAD_DOWN:          {eResult = orxKEYBOARD_KEY_DOWN; break;}
-    case AKEYCODE_DPAD_LEFT:          {eResult = orxKEYBOARD_KEY_LEFT; break;}
-    case AKEYCODE_VOLUME_DOWN:        {eResult = orxKEYBOARD_KEY_VOLUME_DOWN; break;}
-    case AKEYCODE_VOLUME_UP:          {eResult = orxKEYBOARD_KEY_VOLUME_UP; break;}
-    case AKEYCODE_A:                  {eResult = orxKEYBOARD_KEY_A; break;}
-    case AKEYCODE_Z:                  {eResult = orxKEYBOARD_KEY_Z; break;}
-    case AKEYCODE_E:                  {eResult = orxKEYBOARD_KEY_E; break;}
-    case AKEYCODE_R:                  {eResult = orxKEYBOARD_KEY_R; break;}
-    case AKEYCODE_T:                  {eResult = orxKEYBOARD_KEY_T; break;}
-    case AKEYCODE_Y:                  {eResult = orxKEYBOARD_KEY_Y; break;}
-    case AKEYCODE_U:                  {eResult = orxKEYBOARD_KEY_U; break;}
-    case AKEYCODE_I:                  {eResult = orxKEYBOARD_KEY_I; break;}
-    case AKEYCODE_O:                  {eResult = orxKEYBOARD_KEY_O; break;}
-    case AKEYCODE_P:                  {eResult = orxKEYBOARD_KEY_P; break;}
-    case AKEYCODE_Q:                  {eResult = orxKEYBOARD_KEY_Q; break;}
-    case AKEYCODE_S:                  {eResult = orxKEYBOARD_KEY_S; break;}
-    case AKEYCODE_D:                  {eResult = orxKEYBOARD_KEY_D; break;}
-    case AKEYCODE_F:                  {eResult = orxKEYBOARD_KEY_F; break;}
-    case AKEYCODE_G:                  {eResult = orxKEYBOARD_KEY_G; break;}
-    case AKEYCODE_H:                  {eResult = orxKEYBOARD_KEY_H; break;}
-    case AKEYCODE_J:                  {eResult = orxKEYBOARD_KEY_J; break;}
-    case AKEYCODE_K:                  {eResult = orxKEYBOARD_KEY_K; break;}
-    case AKEYCODE_L:                  {eResult = orxKEYBOARD_KEY_L; break;}
-    case AKEYCODE_M:                  {eResult = orxKEYBOARD_KEY_M; break;}
-    case AKEYCODE_W:                  {eResult = orxKEYBOARD_KEY_W; break;}
-    case AKEYCODE_X:                  {eResult = orxKEYBOARD_KEY_X; break;}
-    case AKEYCODE_C:                  {eResult = orxKEYBOARD_KEY_C; break;}
-    case AKEYCODE_V:                  {eResult = orxKEYBOARD_KEY_V; break;}
-    case AKEYCODE_B:                  {eResult = orxKEYBOARD_KEY_B; break;}
-    case AKEYCODE_N:                  {eResult = orxKEYBOARD_KEY_N; break;}
-    case AKEYCODE_0:                  {eResult = orxKEYBOARD_KEY_0; break;}
-    case AKEYCODE_1:                  {eResult = orxKEYBOARD_KEY_1; break;}
-    case AKEYCODE_2:                  {eResult = orxKEYBOARD_KEY_2; break;}
-    case AKEYCODE_3:                  {eResult = orxKEYBOARD_KEY_3; break;}
-    case AKEYCODE_4:                  {eResult = orxKEYBOARD_KEY_4; break;}
-    case AKEYCODE_5:                  {eResult = orxKEYBOARD_KEY_5; break;}
-    case AKEYCODE_6:                  {eResult = orxKEYBOARD_KEY_6; break;}
-    case AKEYCODE_7:                  {eResult = orxKEYBOARD_KEY_7; break;}
-    case AKEYCODE_8:                  {eResult = orxKEYBOARD_KEY_8; break;}
-    case AKEYCODE_9:                  {eResult = orxKEYBOARD_KEY_9; break;}
-    default:                          {eResult = orxKEYBOARD_KEY_NONE; break;}
+    case AKEYCODE_BACK:               { eResult = orxKEYBOARD_KEY_ESCAPE; break; }
+    case AKEYCODE_SPACE:              { eResult = orxKEYBOARD_KEY_SPACE; break; }
+    case AKEYCODE_ENTER:              { eResult = orxKEYBOARD_KEY_ENTER; break; }
+    case AKEYCODE_BUTTON_SELECT:      { eResult = orxKEYBOARD_KEY_ENTER; break; }
+    case AKEYCODE_DEL:                { eResult = orxKEYBOARD_KEY_BACKSPACE; break; }
+    case AKEYCODE_TAB:                { eResult = orxKEYBOARD_KEY_TAB; break; }
+    case AKEYCODE_PAGE_UP:            { eResult = orxKEYBOARD_KEY_PAGE_UP; break; }
+    case AKEYCODE_PAGE_DOWN:          { eResult = orxKEYBOARD_KEY_PAGE_DOWN; break; }
+    case AKEYCODE_PLUS:               { eResult = orxKEYBOARD_KEY_NUMPAD_ADD; break; }
+    case AKEYCODE_STAR:               { eResult = orxKEYBOARD_KEY_NUMPAD_MULTIPLY; break; }
+    case AKEYCODE_MEDIA_PLAY_PAUSE:   { eResult = orxKEYBOARD_KEY_PAUSE; break; }
+    case AKEYCODE_ALT_RIGHT:          { eResult = orxKEYBOARD_KEY_RALT; break; }
+    case AKEYCODE_SHIFT_RIGHT:        { eResult = orxKEYBOARD_KEY_RSHIFT; break; }
+    case AKEYCODE_ALT_LEFT:           { eResult = orxKEYBOARD_KEY_LALT; break; }
+    case AKEYCODE_SHIFT_LEFT:         { eResult = orxKEYBOARD_KEY_LSHIFT; break; }
+    case AKEYCODE_MENU:               { eResult = orxKEYBOARD_KEY_MENU; break; }
+    case AKEYCODE_LEFT_BRACKET:       { eResult = orxKEYBOARD_KEY_LBRACKET; break; }
+    case AKEYCODE_RIGHT_BRACKET:      { eResult = orxKEYBOARD_KEY_RBRACKET; break; }
+    case AKEYCODE_SEMICOLON:          { eResult = orxKEYBOARD_KEY_SEMICOLON; break; }
+    case AKEYCODE_COMMA:              { eResult = orxKEYBOARD_KEY_COMMA; break; }
+    case AKEYCODE_PERIOD:             { eResult = orxKEYBOARD_KEY_PERIOD; break; }
+    case AKEYCODE_APOSTROPHE:         { eResult = orxKEYBOARD_KEY_QUOTE; break; }
+    case AKEYCODE_SLASH:              { eResult = orxKEYBOARD_KEY_SLASH; break; }
+    case AKEYCODE_BACKSLASH:          { eResult = orxKEYBOARD_KEY_BACKSLASH; break; }
+    case AKEYCODE_EQUALS:             { eResult = orxKEYBOARD_KEY_EQUAL; break; }
+    case AKEYCODE_MINUS:              { eResult = orxKEYBOARD_KEY_DASH; break; }
+    case AKEYCODE_DPAD_UP:            { eResult = orxKEYBOARD_KEY_UP; break; }
+    case AKEYCODE_DPAD_RIGHT:         { eResult = orxKEYBOARD_KEY_RIGHT; break; }
+    case AKEYCODE_DPAD_DOWN:          { eResult = orxKEYBOARD_KEY_DOWN; break; }
+    case AKEYCODE_DPAD_LEFT:          { eResult = orxKEYBOARD_KEY_LEFT; break; }
+    case AKEYCODE_VOLUME_DOWN:        { eResult = orxKEYBOARD_KEY_VOLUME_DOWN; break; }
+    case AKEYCODE_VOLUME_UP:          { eResult = orxKEYBOARD_KEY_VOLUME_UP; break; }
+    case AKEYCODE_A:                  { eResult = orxKEYBOARD_KEY_A; break; }
+    case AKEYCODE_Z:                  { eResult = orxKEYBOARD_KEY_Z; break; }
+    case AKEYCODE_E:                  { eResult = orxKEYBOARD_KEY_E; break; }
+    case AKEYCODE_R:                  { eResult = orxKEYBOARD_KEY_R; break; }
+    case AKEYCODE_T:                  { eResult = orxKEYBOARD_KEY_T; break; }
+    case AKEYCODE_Y:                  { eResult = orxKEYBOARD_KEY_Y; break; }
+    case AKEYCODE_U:                  { eResult = orxKEYBOARD_KEY_U; break; }
+    case AKEYCODE_I:                  { eResult = orxKEYBOARD_KEY_I; break; }
+    case AKEYCODE_O:                  { eResult = orxKEYBOARD_KEY_O; break; }
+    case AKEYCODE_P:                  { eResult = orxKEYBOARD_KEY_P; break; }
+    case AKEYCODE_Q:                  { eResult = orxKEYBOARD_KEY_Q; break; }
+    case AKEYCODE_S:                  { eResult = orxKEYBOARD_KEY_S; break; }
+    case AKEYCODE_D:                  { eResult = orxKEYBOARD_KEY_D; break; }
+    case AKEYCODE_F:                  { eResult = orxKEYBOARD_KEY_F; break; }
+    case AKEYCODE_G:                  { eResult = orxKEYBOARD_KEY_G; break; }
+    case AKEYCODE_H:                  { eResult = orxKEYBOARD_KEY_H; break; }
+    case AKEYCODE_J:                  { eResult = orxKEYBOARD_KEY_J; break; }
+    case AKEYCODE_K:                  { eResult = orxKEYBOARD_KEY_K; break; }
+    case AKEYCODE_L:                  { eResult = orxKEYBOARD_KEY_L; break; }
+    case AKEYCODE_M:                  { eResult = orxKEYBOARD_KEY_M; break; }
+    case AKEYCODE_W:                  { eResult = orxKEYBOARD_KEY_W; break; }
+    case AKEYCODE_X:                  { eResult = orxKEYBOARD_KEY_X; break; }
+    case AKEYCODE_C:                  { eResult = orxKEYBOARD_KEY_C; break; }
+    case AKEYCODE_V:                  { eResult = orxKEYBOARD_KEY_V; break; }
+    case AKEYCODE_B:                  { eResult = orxKEYBOARD_KEY_B; break; }
+    case AKEYCODE_N:                  { eResult = orxKEYBOARD_KEY_N; break; }
+    case AKEYCODE_0:                  { eResult = orxKEYBOARD_KEY_0; break; }
+    case AKEYCODE_1:                  { eResult = orxKEYBOARD_KEY_1; break; }
+    case AKEYCODE_2:                  { eResult = orxKEYBOARD_KEY_2; break; }
+    case AKEYCODE_3:                  { eResult = orxKEYBOARD_KEY_3; break; }
+    case AKEYCODE_4:                  { eResult = orxKEYBOARD_KEY_4; break; }
+    case AKEYCODE_5:                  { eResult = orxKEYBOARD_KEY_5; break; }
+    case AKEYCODE_6:                  { eResult = orxKEYBOARD_KEY_6; break; }
+    case AKEYCODE_7:                  { eResult = orxKEYBOARD_KEY_7; break; }
+    case AKEYCODE_8:                  { eResult = orxKEYBOARD_KEY_8; break; }
+    case AKEYCODE_9:                  { eResult = orxKEYBOARD_KEY_9; break; }
+    default:                          { eResult = orxKEYBOARD_KEY_NONE; break; }
   }
 
   /* Done! */
   return eResult;
 }
 
-static void orxFASTCALL orxKeyboard_Android_UpdateKeyFilterState(const orxCLOCK_INFO* pClockInfo, void* pContext)
-{
+static void orxFASTCALL orxKeyboard_Android_UpdateKeyFilterState(const orxCLOCK_INFO* pClockInfo, void* pContext) {
   const orxSTRING zInputSet = orxNULL;
   const orxSTRING zPreviousSet;
   const orxSTRING zName;
 
-#define orxKEYBOARD_UPDATE_BOUND_KEY(KEY)                                                                                                     \
-  if(orxInput_GetBoundInput(orxINPUT_TYPE_KEYBOARD_KEY, orxKEYBOARD_KEY_##KEY, orxINPUT_MODE_FULL, 0, &zName, orxNULL) != orxSTATUS_FAILURE)  \
-  {                                                                                                                                           \
-    orxFLAG_SET(sstKeyboard.u32BoundKeys, orxKEYBOARD_KU32_BOUND_KEY_##KEY, orxKEYBOARD_KU32_BOUND_KEY_NONE);                                 \
-  }
+#define orxKEYBOARD_UPDATE_BOUND_KEY(KEY)                                                                                                       \
+  do                                                                                                                                            \
+  {                                                                                                                                             \
+    if(orxInput_GetBoundInput(orxINPUT_TYPE_KEYBOARD_KEY, orxKEYBOARD_KEY_##KEY, orxINPUT_MODE_FULL, 0, &zName, orxNULL) != orxSTATUS_FAILURE)  \
+    {                                                                                                                                           \
+      orxFLAG_SET(sstKeyboard.u32BoundKeys, orxKEYBOARD_KU32_BOUND_KEY_##KEY, orxKEYBOARD_KU32_BOUND_KEY_NONE);                                 \
+    }                                                                                                                                           \
+  } while(orxFALSE)
 
   /* Unbound keys are handled by system */
   sstKeyboard.u32BoundKeys = orxKEYBOARD_KU32_BOUND_KEY_NONE;
@@ -229,6 +231,8 @@ static void orxFASTCALL orxKeyboard_Android_UpdateKeyFilterState(const orxCLOCK_
       orxInput_SelectSet(zPreviousSet);
     }
   }
+
+#undef orxKEYBOARD_UPDATE_BOUND_KEY
 }
 
 static bool orxKeyboard_Android_KeyEventFilter(const GameActivityKeyEvent *event)
@@ -238,21 +242,29 @@ static bool orxKeyboard_Android_KeyEventFilter(const GameActivityKeyEvent *event
   switch(event->keyCode)
   {
     case AKEYCODE_VOLUME_DOWN:
-      bAllowKey = orxFLAG_TEST(sstKeyboard.u32BoundKeys, orxKEYBOARD_KU32_BOUND_KEY_VOLUME_DOWN) ? true : false;
+    {
+      bAllowKey = orxFLAG_TEST(sstKeyboard.u32BoundKeys, orxKEYBOARD_KU32_BOUND_KEY_VOLUME_DOWN);
       break;
+    }
     case AKEYCODE_VOLUME_UP:
-      bAllowKey = orxFLAG_TEST(sstKeyboard.u32BoundKeys, orxKEYBOARD_KU32_BOUND_KEY_VOLUME_UP) ? true : false;
+    {
+      bAllowKey = orxFLAG_TEST(sstKeyboard.u32BoundKeys, orxKEYBOARD_KU32_BOUND_KEY_VOLUME_UP);
       break;
+    }
     case AKEYCODE_VOLUME_MUTE:
     case AKEYCODE_CAMERA:
     case AKEYCODE_ZOOM_IN:
     case AKEYCODE_ZOOM_OUT:
+    {
       /* Note : Copied from android_native_app_glue.c in AGDK */
       bAllowKey = false;
       break;
+    }
     default:
+    {
       bAllowKey = true;
       break;
+    }
   }
   
   return bAllowKey;
@@ -271,33 +283,36 @@ static orxSTATUS orxFASTCALL orxKeyboard_Android_EventHandler(const orxEVENT *_p
   switch(pstKeyEvent->u32Action)
   {
     case orxANDROID_EVENT_KEYBOARD_DOWN:
+    {
       eKey = orxKeyboard_Android_GetKey(pstKeyEvent->u32KeyCode);
-
-      if(eKey != orxKEYBOARD_KEY_NONE)
+      if (eKey != orxKEYBOARD_KEY_NONE)
       {
         sstKeyboard.abKeyPressed[eKey] = orxTRUE;
 
         /* Stores it */
         sstKeyboard.au32KeyBuffer[sstKeyboard.u32KeyWriteIndex] = pstKeyEvent->u32KeyCode;
-        sstKeyboard.u32KeyWriteIndex = (sstKeyboard.u32KeyWriteIndex + 1) & (orxKEYBOARD_KU32_BUFFER_SIZE - 1);
+        sstKeyboard.u32KeyWriteIndex =
+                (sstKeyboard.u32KeyWriteIndex + 1) & (orxKEYBOARD_KU32_BUFFER_SIZE - 1);
 
         /* Full? */
-        if(sstKeyboard.u32KeyReadIndex == sstKeyboard.u32KeyWriteIndex)
+        if (sstKeyboard.u32KeyReadIndex == sstKeyboard.u32KeyWriteIndex)
         {
           /* Bounces read index */
-          sstKeyboard.u32KeyReadIndex = (sstKeyboard.u32KeyReadIndex + 1) & (orxKEYBOARD_KU32_BUFFER_SIZE - 1);
+          sstKeyboard.u32KeyReadIndex =
+                  (sstKeyboard.u32KeyReadIndex + 1) & (orxKEYBOARD_KU32_BUFFER_SIZE - 1);
         }
       }
       break;
-
+    }
     case orxANDROID_EVENT_KEYBOARD_UP:
+    {
       eKey = orxKeyboard_Android_GetKey(pstKeyEvent->u32KeyCode);
-
       if(eKey != orxKEYBOARD_KEY_NONE)
       {
         sstKeyboard.abKeyPressed[eKey] = orxFALSE;
       }
       break;
+    }
   }
 
   /* Done! */
@@ -317,12 +332,6 @@ extern "C" orxSTATUS orxFASTCALL orxKeyboard_Android_Init()
     /* Adds our keyboard event handlers */
     if((eResult = orxEvent_AddHandler(orxANDROID_EVENT_TYPE_KEYBOARD, orxKeyboard_Android_EventHandler)) != orxSTATUS_FAILURE)
     {
-      int i;
-      for(i = 0; i < orxKEYBOARD_KEY_NUMBER; i++)
-      {
-        sstKeyboard.abKeyPressed[i] = orxFALSE;
-      }
-
       /* Updates status */
       sstKeyboard.u32Flags |= orxKEYBOARD_KU32_STATIC_FLAG_READY;
     }
@@ -331,7 +340,7 @@ extern "C" orxSTATUS orxFASTCALL orxKeyboard_Android_Init()
     orxAndroid_SetKeyFilter(&orxKeyboard_Android_KeyEventFilter);
 
     /* Registers filter state function */
-    orxClock_Register(orxClock_Get(orxCLOCK_KZ_CORE), orxKeyboard_Android_UpdateKeyFilterState, orxNULL, orxMODULE_ID_MAIN, orxCLOCK_PRIORITY_NORMAL);
+    orxClock_Register(orxClock_Get(orxCLOCK_KZ_CORE), orxKeyboard_Android_UpdateKeyFilterState, orxNULL, orxMODULE_ID_KEYBOARD, orxCLOCK_PRIORITY_NORMAL);
   }
 
   /* Done! */

--- a/code/src/io/orxKeyboard.c
+++ b/code/src/io/orxKeyboard.c
@@ -211,6 +211,8 @@ const orxSTRING orxFASTCALL orxKeyboard_GetKeyName(orxKEYBOARD_KEY _eKey)
     }
   }
 
+#undef orxKEYBOARD_DECLARE_KEY_NAME
+
   /* Done! */
   return zResult;
 }

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -341,6 +341,11 @@ extern "C" orxU32 orxAndroid_JNI_GetRotation()
   return rotation;
 }
 
+extern "C" void orxAndroid_SetKeyFilter(android_key_event_filter filter)
+{
+  android_app_set_key_event_filter(sstAndroid.app, filter);
+}
+
 static void Android_CheckForNewAxis()
 {
   /* Tell GameActivity about any new axis ids so it reports their events */

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -630,9 +630,10 @@ void android_main(android_app* state)
 
   /* Initializes SwappyGL */
   SwappyGL_init(env, state->activity->javaGameActivity);
-  SwappyGL_setSwapIntervalNS(SWAPPY_SWAP_60FPS);
+  SwappyGL_setAutoSwapInterval(false);
   SwappyGL_setAutoPipelineMode(false);
   SwappyGL_enableStats(false);
+  SwappyGL_setSwapIntervalNS(SWAPPY_SWAP_60FPS);
 
   /* Gets arguments from manifest */
   orxAndroid_JNI_GetArguments();

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -689,7 +689,6 @@ void android_main(android_app* state)
   SwappyGL_init(env, state->activity->javaGameActivity);
   SwappyGL_setAutoSwapInterval(false);
   SwappyGL_setAutoPipelineMode(false);
-  SwappyGL_enableStats(false);
 
   /* Gets arguments from manifest */
   orxAndroid_JNI_GetArguments();

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -377,7 +377,7 @@ static void Android_HandleGameInput(struct android_app* app)
   /* Early exit if no events. */
   if(ib == NULL)
   {
-      return;
+    return;
   }
 
   if(ib->keyEventsCount != 0)
@@ -391,14 +391,15 @@ static void Android_HandleGameInput(struct android_app* app)
       {
         /* Didn't belong to a game controller, let's process it ourselves. */
 
-        orxANDROID_KEY_EVENT stKeyEvent;
-        /* Inits event payload */
-        orxMemory_Zero(&stKeyEvent, sizeof(orxANDROID_KEY_EVENT));
-        stKeyEvent.u32KeyCode = event->keyCode;
-        stKeyEvent.u32Action = event->action == AKEY_EVENT_ACTION_DOWN ? orxANDROID_EVENT_KEYBOARD_DOWN
-                                                                       : orxANDROID_EVENT_KEYBOARD_UP;
         if(event->action != AKEY_EVENT_ACTION_MULTIPLE)
         {
+          orxANDROID_KEY_EVENT stKeyEvent;
+          /* Inits event payload */
+          orxMemory_Zero(&stKeyEvent, sizeof(orxANDROID_KEY_EVENT));
+          stKeyEvent.u32KeyCode = event->keyCode;
+          stKeyEvent.u32Action = event->action == AKEY_EVENT_ACTION_DOWN ? orxANDROID_EVENT_KEYBOARD_DOWN
+                                                                         : orxANDROID_EVENT_KEYBOARD_UP;
+
           orxEVENT_SEND(orxANDROID_EVENT_TYPE_KEYBOARD, 0, orxNULL, orxNULL, &stKeyEvent);
         }
       }

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -630,10 +630,7 @@ void android_main(android_app* state)
 
   /* Initializes SwappyGL */
   SwappyGL_init(env, state->activity->javaGameActivity);
-  SwappyGL_setAutoSwapInterval(false);
-  SwappyGL_setAutoPipelineMode(false);
   SwappyGL_enableStats(false);
-  SwappyGL_setSwapIntervalNS(SWAPPY_SWAP_60FPS);
 
   /* Gets arguments from manifest */
   orxAndroid_JNI_GetArguments();

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -631,6 +631,7 @@ void android_main(android_app* state)
   /* Initializes SwappyGL */
   SwappyGL_init(env, state->activity->javaGameActivity);
   SwappyGL_setSwapIntervalNS(SWAPPY_SWAP_60FPS);
+  SwappyGL_setAutoPipelineMode(false);
   SwappyGL_enableStats(false);
 
   /* Gets arguments from manifest */

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -437,26 +437,32 @@ static void Android_HandleGameInput(struct android_app* app)
         switch (event->action & AMOTION_EVENT_ACTION_MASK)
         {
           case AMOTION_EVENT_ACTION_POINTER_DOWN:
+          {
             iIndex = orxANDROID_GET_ACTION_INDEX(event->action);
             stPayload.stTouch.u32ID = event->pointers[iIndex].id;
             stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, iIndex);
             stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, iIndex);
             orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_BEGIN, orxNULL, orxNULL, &stPayload);
             break;
+          }
           case AMOTION_EVENT_ACTION_POINTER_UP:
+          {
             iIndex = orxANDROID_GET_ACTION_INDEX(event->action);
             stPayload.stTouch.u32ID = event->pointers[iIndex].id;
             stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, iIndex);
             stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, iIndex);
             orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_END, orxNULL, orxNULL, &stPayload);
             break;
+          }
           case AMOTION_EVENT_ACTION_DOWN:
+          {
             iIndex = orxANDROID_GET_ACTION_INDEX(event->action);
             stPayload.stTouch.u32ID = event->pointers[iIndex].id;
             stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, iIndex);
             stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, iIndex);
             orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_BEGIN, orxNULL, orxNULL, &stPayload);
             break;
+          }
           case AMOTION_EVENT_ACTION_UP:
           case AMOTION_EVENT_ACTION_CANCEL:
           {
@@ -468,6 +474,7 @@ static void Android_HandleGameInput(struct android_app* app)
             break;
           }
           case AMOTION_EVENT_ACTION_MOVE:
+          {
             for(iIndex = 0; iIndex < event->pointerCount; iIndex++)
             {
               stPayload.stTouch.u32ID = event->pointers[iIndex].id;
@@ -476,6 +483,7 @@ static void Android_HandleGameInput(struct android_app* app)
               orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_MOVE, orxNULL, orxNULL, &stPayload);
             }
             break;
+          }
         }
       }
     }
@@ -488,69 +496,112 @@ static void orxAndroid_handleCmd(struct android_app *app, int32_t cmd)
 {
   switch(cmd)
   {
-    case APP_CMD_PAUSE:
-      LOGI("APP_CMD_PAUSE");
-
-      sstAndroid.bPaused = orxTRUE;
-      orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_BACKGROUND);
+    case APP_CMD_INIT_WINDOW:
+    {
+      LOGI("APP_CMD_INIT_WINDOW");
+      SwappyGL_setWindow(app->window);
+      orxEVENT_SEND(orxANDROID_EVENT_TYPE_SURFACE, orxANDROID_EVENT_SURFACE_CREATED, orxNULL, orxNULL, orxNULL);
       break;
-    case APP_CMD_RESUME:
-      LOGI("APP_CMD_RESUME");
-
-      sstAndroid.bPaused = orxFALSE;
-      orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_FOREGROUND);
-      break;
-    case APP_CMD_START:
-      LOGI("APP_CMD_START");
-      Paddleboat_onStart(orxAndroid_JNI_GetEnv());
-      break;
-    case APP_CMD_STOP:
-      LOGI("APP_CMD_STOP");
-      Paddleboat_onStop(orxAndroid_JNI_GetEnv());
-      break;
+    }
     case APP_CMD_TERM_WINDOW:
+    {
       LOGI("APP_CMD_TERM_WINDOW");
-
       SwappyGL_setWindow(nullptr);
       sstAndroid.fSurfaceScale = orxFLOAT_0;
       orxEVENT_SEND(orxANDROID_EVENT_TYPE_SURFACE, orxANDROID_EVENT_SURFACE_DESTROYED, orxNULL, orxNULL, orxNULL);
       break;
-    case APP_CMD_INIT_WINDOW:
-      LOGI("APP_CMD_INIT_WINDOW");
-
-      SwappyGL_setWindow(app->window);
-      orxEVENT_SEND(orxANDROID_EVENT_TYPE_SURFACE, orxANDROID_EVENT_SURFACE_CREATED, orxNULL, orxNULL, orxNULL);
+    }
+    case APP_CMD_WINDOW_RESIZED:
+    {
+      LOGI("APP_CMD_WINDOW_RESIZED");
       break;
+    }
+    case APP_CMD_WINDOW_REDRAW_NEEDED:
+    {
+      LOGI("APP_CMD_WINDOW_REDRAW_NEEDED");
+      break;
+    }
     case APP_CMD_CONTENT_RECT_CHANGED:
-      {
-        LOGI("APP_CMD_CONTENT_RECT_CHANGED");
+    {
+      LOGI("APP_CMD_CONTENT_RECT_CHANGED");
+      orxANDROID_SURFACE_CHANGED_EVENT stSurfaceChangedEvent;
+      stSurfaceChangedEvent.u32Width = app->contentRect.right - app->contentRect.left;
+      stSurfaceChangedEvent.u32Height = app->contentRect.bottom - app->contentRect.top;
 
-        orxANDROID_SURFACE_CHANGED_EVENT stSurfaceChangedEvent;
-        stSurfaceChangedEvent.u32Width = app->contentRect.right - app->contentRect.left;
-        stSurfaceChangedEvent.u32Height = app->contentRect.bottom - app->contentRect.top;
-
-        orxEVENT_SEND(orxANDROID_EVENT_TYPE_SURFACE, orxANDROID_EVENT_SURFACE_CHANGED, orxNULL, orxNULL, &stSurfaceChangedEvent);
-        sstAndroid.fSurfaceScale = orxFLOAT_0;
-      }
+      orxEVENT_SEND(orxANDROID_EVENT_TYPE_SURFACE, orxANDROID_EVENT_SURFACE_CHANGED, orxNULL, orxNULL, &stSurfaceChangedEvent);
+      sstAndroid.fSurfaceScale = orxFLOAT_0;
       break;
-    case APP_CMD_DESTROY:
-      LOGI("APP_CMD_DESTROY");
-      orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_CLOSE);
-      break;
+    }
     case APP_CMD_GAINED_FOCUS:
+    {
       LOGI("APP_CMD_GAINED_FOCUS");
-
       sstAndroid.bHasFocus = orxTRUE;
       orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_FOCUS_GAINED);
       break;
+    }
     case APP_CMD_LOST_FOCUS:
+    {
       LOGI("APP_CMD_LOST_FOCUS");
-
       sstAndroid.bHasFocus = orxFALSE;
       orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_FOCUS_LOST);
       break;
-    default:
+    }
+    case APP_CMD_CONFIG_CHANGED:
+    {
+      LOGI("APP_CMD_CONFIG_CHANGED");
       break;
+    }
+    case APP_CMD_LOW_MEMORY:
+    {
+      LOGI("APP_CMD_LOW_MEMORY");
+      break;
+    }
+    case APP_CMD_START:
+    {
+      LOGI("APP_CMD_START");
+      Paddleboat_onStart(orxAndroid_JNI_GetEnv());
+      break;
+    }
+    case APP_CMD_RESUME:
+    {
+      LOGI("APP_CMD_RESUME");
+      sstAndroid.bPaused = orxFALSE;
+      orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_FOREGROUND);
+      break;
+    }
+    case APP_CMD_SAVE_STATE:
+    {
+      LOGI("APP_CMD_SAVE_STATE");
+      break;
+    }
+    case APP_CMD_PAUSE:
+    {
+      LOGI("APP_CMD_PAUSE");
+      sstAndroid.bPaused = orxTRUE;
+      orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_BACKGROUND);
+      break;
+    }
+    case APP_CMD_STOP:
+    {
+      LOGI("APP_CMD_STOP");
+      Paddleboat_onStop(orxAndroid_JNI_GetEnv());
+      break;
+    }
+    case APP_CMD_DESTROY:
+    {
+      LOGI("APP_CMD_DESTROY");
+      orxEvent_SendShort(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_CLOSE);
+      break;
+    }
+    case APP_CMD_WINDOW_INSETS_CHANGED:
+    {
+      LOGI("APP_CMD_WINDOW_INSETS_CHANGED");
+      break;
+    }
+    default:
+    {
+      break;
+    }
   }
 }
 

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -636,6 +636,8 @@ void android_main(android_app* state)
 
   /* Initializes SwappyGL */
   SwappyGL_init(env, state->activity->javaGameActivity);
+  SwappyGL_setAutoSwapInterval(false);
+  SwappyGL_setAutoPipelineMode(false);
   SwappyGL_enableStats(false);
 
   /* Gets arguments from manifest */

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -630,8 +630,7 @@ void android_main(android_app* state)
 
   /* Initializes SwappyGL */
   SwappyGL_init(env, state->activity->javaGameActivity);
-  SwappyGL_setAutoSwapInterval(false);
-  SwappyGL_setAutoPipelineMode(false);
+  SwappyGL_setSwapIntervalNS(SWAPPY_SWAP_60FPS);
   SwappyGL_enableStats(false);
 
   /* Gets arguments from manifest */


### PR DESCRIPTION
* Swappy: Auto-swap interval disabled until further notice.
* Swappy: Re-enabled support for custom frame rates.
* Swappy: Custom key filter. Orx will handle volume up/down if bound by any input set.
* Swappy: Implemented `GetVideoModeCount()`, `GetVideoMode()` and `IsVideoModeAvailable()`
* Ability to control profiler using joypad in `orx Demo`.
* Bumped AGDK to 2.0.0
* New icon background color.
* Fix: The usage of `orxAndroid_PumpEvents()` was incorrect.
* Fix: Profiling got disabled due to type in \_\_orxPROFILER\_\_.

**Regarding refresh rates**
There is no way to set the system refresh rate. For the orx game itself, refresh rate defaults to 60. Lower values are not checked (verified that 30 and 20 work), and I'm not sure it's needed since we never set the system refresh rate. Higher values are clamped to 60 if "Smooth Display" is disabled, otherwise clamped to 90 (or whatever high frame rate the device supports).

**Known issues**
There is a known bug (also present in `master`) where keyboard presses are incorrectly timed unless you also touch the screen. See [issues/276316114](https://issuetracker.google.com/issues/276316114).

`GetVideoModeCount()` may return 0 if called too early.

**Workarounds**
Found workarounds for these `Swappy` issues:
* https://issuetracker.google.com/issues/277025563
* https://issuetracker.google.com/issues/277422871

**Future work**
All in all, this PR improves on some AGDK related glitches here and there. Later on, we could potentially benefit from enabling auto-swapping. Additional testing needed! However, if we take this path we need to _detect_ when frame rate changes and signal the change to the clock. We can probably poll this value using `SwappyGL_getRefreshPeriodNanos()`.