### PR TITLE
AGDK integration: Improved key handling

### DIFF
--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -78,9 +78,9 @@ dependencies {
     api 'androidx.core:core:1.9.0'
     api 'androidx.appcompat:appcompat:1.6.1'
 
-    api 'androidx.games:games-activity:2.0.1'
+    api 'androidx.games:games-activity:2.0.2'
     api 'androidx.games:games-controller:2.0.0'
-    api 'androidx.games:games-frame-pacing:2.0.0'
+    api 'androidx.games:games-frame-pacing:2.1.0-beta01'
 }
 
 afterEvaluate {

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -135,12 +135,12 @@
 #define orxDISPLAY_NANO_INVERSE(N)              (0.5 + 1000000000.0 / (N))
 
 #define orxDISPLAY_orxU32_BIT                   32
-#define orxDISPLAY_BIT_MASK(b)                   (1 << ((b) % orxDISPLAY_orxU32_BIT))
-#define orxDISPLAY_BIT_SLOT(b)                   ((b) / orxDISPLAY_orxU32_BIT)
-#define orxDISPLAY_BIT_SET(a, b)                 ((a)[orxDISPLAY_BIT_SLOT(b)] |= orxDISPLAY_BIT_MASK(b))
-#define orxDISPLAY_BIT_CLEAR(a, b)               ((a)[orxDISPLAY_BIT_SLOT(b)] &= ~orxDISPLAY_BIT_MASK(b))
-#define orxDISPLAY_BIT_TEST(a, b)                ((a)[orxDISPLAY_BIT_SLOT(b)] & orxDISPLAY_BIT_MASK(b))
-#define orxDISPLAY_BIT_NSLOTS(nb)                ((nb + orxDISPLAY_orxU32_BIT - 1) / orxDISPLAY_orxU32_BIT)
+#define orxDISPLAY_BIT_MASK(b)                  (1 << ((b) % orxDISPLAY_orxU32_BIT))
+#define orxDISPLAY_BIT_SLOT(b)                  ((b) / orxDISPLAY_orxU32_BIT)
+#define orxDISPLAY_BIT_SET(a, b)                ((a)[orxDISPLAY_BIT_SLOT(b)] |= orxDISPLAY_BIT_MASK(b))
+#define orxDISPLAY_BIT_CLEAR(a, b)              ((a)[orxDISPLAY_BIT_SLOT(b)] &= ~orxDISPLAY_BIT_MASK(b))
+#define orxDISPLAY_BIT_TEST(a, b)               ((a)[orxDISPLAY_BIT_SLOT(b)] & orxDISPLAY_BIT_MASK(b))
+#define orxDISPLAY_BIT_NSLOTS(nb)               ((nb + orxDISPLAY_orxU32_BIT - 1) / orxDISPLAY_orxU32_BIT)
 
 #define orxDISPLAY_KU32_RATE_BUFFER_SIZE        orxDISPLAY_BIT_NSLOTS(orxDISPLAY_KU32_MAX_REFRESH_RATE + 1)
 

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -381,6 +381,7 @@ static void orxAndroid_SendKey(orxU32 u32KeyCode, orxU32 u32Action)
   orxASSERT(u32Action == AKEY_EVENT_ACTION_DOWN || u32Action == AKEY_EVENT_ACTION_UP);
 
   /* Inits event payload */
+  orxMemory_Zero(&stKeyEvent, sizeof(orxANDROID_KEY_EVENT));
   stKeyEvent.u32KeyCode = u32KeyCode;
   stKeyEvent.u32Action = u32Action == AKEY_EVENT_ACTION_DOWN ? orxANDROID_EVENT_KEYBOARD_DOWN
                                                              : orxANDROID_EVENT_KEYBOARD_UP;


### PR DESCRIPTION
This fixes the bug where key down/up events were handled in the same frame, causing `orx` to miss the key presses. See [issue 276316114](https://issuetracker.google.com/issues/276316114). Let's hope that AGDK samples/docs are updated to highlight the need for the buffering.

Also bumped `GameActivity` and its siblings. This fixes [issue 277422871](https://issuetracker.google.com/issues/277422871). Hence the removal of our "refresh rate fix" workaround.