### PR TITLE
orxFontGen font optimization (specific case)

### DIFF
--- a/tools/orxFontGen/src/orxFontGen.c
+++ b/tools/orxFontGen/src/orxFontGen.c
@@ -693,7 +693,7 @@ static void Run()
         orxS32            s32LargestWidth = 0;
 
         // For all defined glyphs
-        for(pstGlyph = (orxFONTGEN_GLYPH *)orxLinkList_GetFirst(&sstFontGen.stGlyphList);
+        for(pstGlyph = (orxFONTGEN_GLYPH *)orxLinkList_GetFirst(&sstFontGen.stGlyphList), s32MaxAscend = 0, s32MaxDescend = 0;
             pstGlyph;
             pstGlyph = (orxFONTGEN_GLYPH *)orxLinkList_GetNext(&pstGlyph->stNode))
         {
@@ -716,12 +716,27 @@ static void Run()
             s32CharacterWidth = orxMAX((orxS32)sstFontGen.pstFontFace->glyph->bitmap_left, 0) + (orxS32)sstFontGen.pstFontFace->glyph->bitmap.width;
           }
 
+          // Is ascend bigger than any previous?
+          if ((orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxAscend)
+          {
+            // Stores it
+            s32MaxAscend = (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top;
+          }
+
+          // Is descend bigger than any previous?
+          if ((orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxDescend)
+          {
+            // Stores it
+            s32MaxDescend = (orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top;
+          }
+
           // Updates largest character width
           s32LargestWidth = orxMAX(s32LargestWidth, s32CharacterWidth);
         }
 
-        // Updates character width
+        // Updates character width and height
         sstFontGen.vCharacterSize.fX = orxS2F(s32LargestWidth);
+        sstFontGen.vCharacterSize.fY = orxS2F(s32MaxAscend + s32MaxDescend + 1);
       }
 
       // Gets width & height
@@ -737,7 +752,7 @@ static void Run()
         orxFONTGEN_GLYPH *pstGlyph;
 
         // For all defined glyphs
-        for(pstGlyph = (orxFONTGEN_GLYPH *)orxLinkList_GetFirst(&sstFontGen.stGlyphList), s32X = 0, s32Y = 0, s32MaxAscend = 0, s32MaxDescend = 0;
+        for(pstGlyph = (orxFONTGEN_GLYPH *)orxLinkList_GetFirst(&sstFontGen.stGlyphList), s32X = 0, s32Y = 0;
             pstGlyph;
             pstGlyph = (orxFONTGEN_GLYPH *)orxLinkList_GetNext(&pstGlyph->stNode))
         {
@@ -747,20 +762,6 @@ static void Run()
           // Loads rendered glyph
           eError = FT_Load_Glyph(sstFontGen.pstFontFace, (FT_UInt)pstGlyph->u32Index, FT_LOAD_RENDER);
           orxASSERT(!eError);
-
-          // Is ascend bigger than any previous?
-          if((orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxAscend)
-          {
-            // Stores it
-            s32MaxAscend = (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top;
-          }
-
-          // Is descend bigger than any previous?
-          if((orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxDescend)
-          {
-            // Stores it
-            s32MaxDescend = (orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top;
-          }
 
           // Use original advance value?
           if(orxFLAG_TEST(sstFontGen.u32Flags, orxFONTGEN_KU32_STATIC_FLAG_ADVANCE))

--- a/tools/orxFontGen/src/orxFontGen.c
+++ b/tools/orxFontGen/src/orxFontGen.c
@@ -717,14 +717,14 @@ static void Run()
           }
 
           // Is ascend bigger than any previous?
-          if ((orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxAscend)
+          if((orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxAscend)
           {
             // Stores it
             s32MaxAscend = (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top;
           }
 
           // Is descend bigger than any previous?
-          if ((orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxDescend)
+          if((orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top > s32MaxDescend)
           {
             // Stores it
             s32MaxDescend = (orxS32)sstFontGen.pstFontFace->glyph->bitmap.rows - (orxS32)sstFontGen.pstFontFace->glyph->bitmap_top;
@@ -736,7 +736,11 @@ static void Run()
 
         // Updates character width and height
         sstFontGen.vCharacterSize.fX = orxS2F(s32LargestWidth);
-        sstFontGen.vCharacterSize.fY = orxS2F(s32MaxAscend + s32MaxDescend + 1);
+
+        if(sstFontGen.vCharacterSize.fY > s32MaxAscend + s32MaxDescend + 1)
+        {
+          sstFontGen.vCharacterSize.fY = orxS2F(s32MaxAscend + s32MaxDescend + 1);
+        }
       }
 
       // Gets width & height


### PR DESCRIPTION
When generating non-monospaced fonts, the generated texture sometimes contains unnecessarily large padding at the top and bottom. I.e. When rendering glyphs with no or little use of ascend/descend, like digits.

The fix is rather simple. The calculation of max ascend and max descend is now calculated earlier, allowing us to set a new character height to `maxAscent + maxDescent + 1`. In most cases it will not differ, but for certain setups we can save a pixel area of almost an entire glyph row.