### PR TITLE
Make object parameter const for orxObject_GetTextString

### DIFF
--- a/code/include/object/orxObject.h
+++ b/code/include/object/orxObject.h
@@ -844,7 +844,7 @@ extern orxDLLAPI orxSTATUS orxFASTCALL      orxObject_SetTextString(orxOBJECT *_
  * @param[in]   _pstObject      Concerned object
  * @return      orxSTRING / orxSTRING_EMPTY
  */
-extern orxDLLAPI const orxSTRING orxFASTCALL orxObject_GetTextString(orxOBJECT *_pstObject);
+extern orxDLLAPI const orxSTRING orxFASTCALL orxObject_GetTextString(const orxOBJECT *_pstObject);
 /** @} */
 
 

--- a/code/src/object/orxObject.c
+++ b/code/src/object/orxObject.c
@@ -10171,7 +10171,7 @@ orxSTATUS orxFASTCALL orxObject_SetTextString(orxOBJECT *_pstObject, const orxST
  * @param[in]   _pstObject      Concerned object
  * @return      orxSTRING / orxSTRING_EMPTY
  */
-const orxSTRING orxFASTCALL orxObject_GetTextString(orxOBJECT *_pstObject)
+const orxSTRING orxFASTCALL orxObject_GetTextString(const orxOBJECT *_pstObject)
 {
   orxGRAPHIC     *pstGraphic;
   const orxSTRING zResult = orxSTRING_EMPTY;


### PR DESCRIPTION
From what I can tell, this is a safe change to make. I've tested on macOS locally, and the appveyor CI should hopefully catch platform issues elsewhere if they exist!