### PR TITLE
Added .gitattributes for streamlined LF/CRLF handling.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Treat all files as non-text when doing line-ending-normalization, disabling it completely.
+# Other text-specific git commands are unaffected. Only line ending normalization is changed.
+* -text


### PR DESCRIPTION
With this file, line endings are **not** converted. This implies that you can clone the repository in an "auto convert to CRLF" environment (quite common when using `Git for Windows`) without introducing `CR` characters that could potentially break the build in a "no conversion" environment.

For instance, we know that `setup.sh` cannot be run on Linux if it contains `CRLF` line endings.