### PR TITLE
Android 16KiB page size support

### DIFF
--- a/code/build/android/build.gradle
+++ b/code/build/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.5.1' apply false
+    id 'com.android.library' version '8.5.2' apply false
 }

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -8,8 +8,8 @@ android {
     compileSdk sdkVersion.toInteger()
 
     // Ideally, we want to use the default NDK version for the used AGP version.
-    // However, we opt-in to NDK r26 since it comes with many important features/optimizations.
-    ndkVersion '26.3.11579264'
+    // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
+    ndkVersion '27.0.12077973'
 
     buildFeatures {
         prefab true
@@ -94,9 +94,9 @@ dependencies {
     api 'androidx.core:core:1.13.1'
     api 'androidx.appcompat:appcompat:1.7.0'
 
-    api 'androidx.games:games-activity:3.0.4'
+    api 'androidx.games:games-activity:3.0.5'
     api 'androidx.games:games-controller:2.0.2'
-    api 'androidx.games:games-frame-pacing:2.1.1'
+    api 'androidx.games:games-frame-pacing:2.1.2'
 }
 
 afterEvaluate {

--- a/code/build/android/orx/src/main/jni/Application.mk
+++ b/code/build/android/orx/src/main/jni/Application.mk
@@ -3,3 +3,4 @@ APP_PLATFORM := android-21
 APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
 APP_STL := c++_shared
 APP_STRIP_MODE := none
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -5,8 +5,8 @@ android {
     compileSdk sdkVersion.toInteger()
 
     // Ideally, we want to use the default NDK version for the used AGP version.
-    // However, we opt-in to NDK r26 since it comes with many important features/optimizations.
-    ndkVersion '26.3.11579264'
+    // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
+    ndkVersion '27.0.12077973'
 
     buildFeatures.prefab true
 

--- a/code/demo/android/app/src/main/jni/Application.mk
+++ b/code/demo/android/app/src/main/jni/Application.mk
@@ -2,3 +2,4 @@ APP_MODULES := orxDemo
 APP_PLATFORM := android-21
 APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
 APP_STL := c++_shared
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/code/demo/android/build.gradle
+++ b/code/demo/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.5.1' apply false
+    id 'com.android.library' version '8.5.2' apply false
 }

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -662,7 +662,6 @@ extern "C" void orxAndroid_PumpEvents()
 {
   /* Read all pending events. */
   int id;
-  int events;
   android_poll_source *source;
 
   /* Check if we are exiting. */
@@ -675,7 +674,7 @@ extern "C" void orxAndroid_PumpEvents()
    * If animating, we loop until all events are read, then continue
    * to draw the next frame of animation.
    */
-  while((id = ALooper_pollAll(orxAndroid_IsInteractible() ? 0 : -1, NULL, &events, (void **) &source)) >= 0)
+  while((id = ALooper_pollOnce(orxAndroid_IsInteractible() ? 0 : -1, NULL, NULL, (void **) &source)) >= 0)
   {
     /* Process this event. */
     if(source != NULL)
@@ -768,12 +767,11 @@ void android_main(android_app *_pstState)
 
     /* pumps final events */
     int id;
-    int events;
     android_poll_source *source;
 
     _pstState->onAppCmd = NULL;
 
-    while((id = ALooper_pollAll(-1, NULL, &events, (void **)&source)) >= 0)
+    while((id = ALooper_pollOnce(-1, NULL, NULL, (void **)&source)) >= 0)
     {
       /* Process this event. */
       if(source != NULL)


### PR DESCRIPTION
**Support for [16 KiB page sizes](https://developer.android.com/guide/practices/page-sizes)**. An upcoming feature in `Android 15`. Still **not** tested on a 16 KB device since that involves many tiresome steps. Today's devices are unaffected (correctness verified on two devices).

Also bumped the AGDK libraries. Apparently, [this version](https://developer.android.com/jetpack/androidx/releases/games#games-frame-pacing-2.1.2) fixes frame-drops on 120Hz devices running API 33 or later.

All in all, these are the changes:
* Using NDK r27.
* Added support for 16 KiB page sizes.
* AGDK libraries bumped.

TODO: Verify that an emulated 16 KB device can run `orx Demo`.