### PR TITLE
Updated vscode configuration with C/C++ extension support

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -30,7 +30,7 @@
       ],
       "defines": [],
       "macFrameworkPath": [],
-      "compilerPath": "mingw32-gcc.exe",
+      "compilerPath": "gcc.exe",
       "cStandard": "c17",
       "cppStandard": "c++20",
       "intelliSenseMode": "windows-gcc-x64"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
         "${workspaceFolder}/code/include/**"
       ],
       "defines": [],
-      "compilerPath": "/usr/bin/gcc",
+      "compilerPath": "gcc",
       "cStandard": "c17",
       "cppStandard": "c++20",
       "intelliSenseMode": "linux-gcc-x64"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,40 @@
+{
+  "configurations": [
+    {
+      "name": "Linux",
+      "includePath": [
+        "${workspaceFolder}/code/include/**"
+      ],
+      "defines": [],
+      "compilerPath": "/usr/bin/gcc",
+      "cStandard": "c17",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "linux-gcc-x64"
+    },
+    {
+      "name": "Mac",
+      "includePath": [
+        "${workspaceFolder}/code/include/**"
+      ],
+      "defines": [],
+      "macFrameworkPath": [],
+      "compilerPath": "/usr/bin/clang++",
+      "cStandard": "c17",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "macos-clang-arm64"
+    },
+    {
+      "name": "Win32",
+      "includePath": [
+        "${workspaceFolder}/code/include/**"
+      ],
+      "defines": [],
+      "macFrameworkPath": [],
+      "compilerPath": "mingw32-gcc.exe",
+      "cStandard": "c17",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "windows-gcc-x64"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -18,7 +18,7 @@
       ],
       "defines": [],
       "macFrameworkPath": [],
-      "compilerPath": "/usr/bin/clang++",
+      "compilerPath": "clang++",
       "cStandard": "c17",
       "cppStandard": "c++20",
       "intelliSenseMode": "macos-clang-arm64"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,16 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug (lldb/gdb)",
+      "name": "Debug bounce demo (lldb/gdb)",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/bin/[name]d",
+      "program": "${workspaceFolder}/code/bin/orxd",
       "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
       "environment": [],
       "externalConsole": false,
-      "preLaunchTask": "Build [name] (debug)",
+      "preLaunchTask": "Build orx (debug)",
       "linux": {
         "MIMode": "gdb"
       },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "files.associations": {
-        "orxandroid.h": "c"
-    }
+  "files.associations": {
+    "orxandroid.h": "c"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "files.associations": {
-    "orxandroid.h": "c"
+    "orxAndroid.h": "c"
   }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,12 +7,26 @@
   "type": "shell",
   "linux": {
     "options": {
-      "cwd": "code/build/linux/gmake/"
+      "cwd": "code/build/linux/gmake/",
+      "problemMatcher": {
+        "base": "$gcc",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/code/build/linux/gmake/"
+        ]
+      }
     }
   },
   "osx": {
     "options": {
-      "cwd": "code/build/mac/gmake/"
+      "cwd": "code/build/mac/gmake/",
+      "problemMatcher": {
+        "base": "$gcc",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/code/build/mac/gmake/"
+        ]
+      }
     }
   },
   "windows": {
@@ -23,6 +37,13 @@
         "args": [
           "/d",
           "/c"
+        ]
+      },
+      "problemMatcher": {
+        "base": "$gcc",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/code/build/windows/gmake/"
         ]
       }
     }
@@ -57,9 +78,7 @@
         "Build orx (profile)",
         "Build orx (release)"
       ],
-      "problemMatcher": [
-        "$gcc"
-      ]
+      "problemMatcher": "$gcc"
     },
     {
       "label": "Build orx (debug)",
@@ -75,10 +94,7 @@
       },
       "windows": {
         "command": "mingw32-make.exe -j config=debug64"
-      },
-      "problemMatcher": [
-        "$gcc"
-      ]
+      }
     },
     {
       "label": "Build orx (profile)",
@@ -92,10 +108,7 @@
       },
       "windows": {
         "command": "mingw32-make.exe -j config=profile64"
-      },
-      "problemMatcher": [
-        "$gcc"
-      ]
+      }
     },
     {
       "label": "Build orx (release)",
@@ -109,10 +122,7 @@
       },
       "windows": {
         "command": "mingw32-make.exe -j config=release64"
-      },
-      "problemMatcher": [
-        "$gcc"
-      ]
+      }
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -123,6 +123,51 @@
       "windows": {
         "command": "mingw32-make.exe -j config=release64"
       }
+    },
+    {
+      "label": "Run bounce demo (debug)",
+      "dependsOn": [
+        "Build orx (debug)"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "type": "process",
+      "command": "orxd",
+      "options": {
+        "cwd": "${workspaceFolder}/code/bin/"
+      }
+    },
+    {
+      "label": "Run bounce demo (release)",
+      "dependsOn": [
+        "Build orx (release)"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": false
+      },
+      "type": "process",
+      "command": "orx",
+      "options": {
+        "cwd": "${workspaceFolder}/code/bin/"
+      }
+    },
+    {
+      "label": "Run bounce demo (profile)",
+      "dependsOn": [
+        "Build orx (profile)"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": false
+      },
+      "type": "process",
+      "command": "orxp",
+      "options": {
+        "cwd": "${workspaceFolder}/code/bin/"
+      }
     }
   ]
 }

--- a/code/build/template/.vscode/c_cpp_properties.json
+++ b/code/build/template/.vscode/c_cpp_properties.json
@@ -1,0 +1,43 @@
+{
+  "configurations": [
+    {
+      "name": "Linux",
+      "includePath": [
+        "${workspaceFolder}/include/**",
+        "${env:ORX}/include"
+      ],
+      "defines": [],
+      "compilerPath": "/usr/bin/gcc",
+      "cStandard": "c17",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "linux-gcc-x64"
+    },
+    {
+      "name": "Mac",
+      "includePath": [
+        "${workspaceFolder}/include/**",
+        "${env:ORX}/include"
+      ],
+      "defines": [],
+      "macFrameworkPath": [],
+      "compilerPath": "/usr/bin/clang++",
+      "cStandard": "c17",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "macos-clang-arm64"
+    },
+    {
+      "name": "Win32",
+      "includePath": [
+        "${workspaceFolder}/include/**",
+        "${env:ORX}/include"
+      ],
+      "defines": [],
+      "macFrameworkPath": [],
+      "compilerPath": "mingw32-gcc.exe",
+      "cStandard": "c17",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "windows-gcc-x64"
+    }
+  ],
+  "version": 4
+}

--- a/code/build/template/.vscode/c_cpp_properties.json
+++ b/code/build/template/.vscode/c_cpp_properties.json
@@ -7,7 +7,7 @@
         "${env:ORX}/include"
       ],
       "defines": [],
-      "compilerPath": "/usr/bin/gcc",
+      "compilerPath": "gcc",
       "cStandard": "c17",
       "cppStandard": "c++20",
       "intelliSenseMode": "linux-gcc-x64"

--- a/code/build/template/.vscode/c_cpp_properties.json
+++ b/code/build/template/.vscode/c_cpp_properties.json
@@ -20,7 +20,7 @@
       ],
       "defines": [],
       "macFrameworkPath": [],
-      "compilerPath": "/usr/bin/clang++",
+      "compilerPath": "clang++",
       "cStandard": "c17",
       "cppStandard": "c++20",
       "intelliSenseMode": "macos-clang-arm64"

--- a/code/build/template/.vscode/c_cpp_properties.json
+++ b/code/build/template/.vscode/c_cpp_properties.json
@@ -33,7 +33,7 @@
       ],
       "defines": [],
       "macFrameworkPath": [],
-      "compilerPath": "mingw32-gcc.exe",
+      "compilerPath": "gcc.exe",
       "cStandard": "c17",
       "cppStandard": "c++20",
       "intelliSenseMode": "windows-gcc-x64"

--- a/code/build/template/.vscode/launch.json
+++ b/code/build/template/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug (lldb/gdb)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/[name]d",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "preLaunchTask": "Build [name] (debug)",
+      "linux": {
+        "MIMode": "gdb"
+      },
+      "osx": {
+        "MIMode": "lldb"
+      },
+      "windows": {
+        "MIMode": "gdb"
+      }
+    },
+    {
+      "name": "Debug (MSVC/Visual Studio 2022)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/[name]d.exe",
+      "symbolSearchPath": "${workspaceFolder}/build/windows/vs2022/obj/x64/Debug",
+      "externalConsole": true,
+      "logging": {
+        "moduleLoad": false,
+        "engineLogging": false,
+        "trace": true,
+        "traceResponse": true
+      },
+      "visualizerFile": "${workspaceFolder}/[name].natvis",
+      "cwd": "${workspaceFolder}/bin"
+    }
+  ]
+}

--- a/code/build/template/.vscode/tasks.json
+++ b/code/build/template/.vscode/tasks.json
@@ -7,12 +7,26 @@
   "type": "shell",
   "linux": {
     "options": {
-      "cwd": "build/linux/gmake/"
+      "cwd": "build/linux/gmake/",
+      "problemMatcher": {
+        "base": "$gcc",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/build/linux/gmake/"
+        ]
+      }
     }
   },
   "osx": {
     "options": {
-      "cwd": "build/mac/gmake/"
+      "cwd": "build/mac/gmake/",
+      "problemMatcher": {
+        "base": "$gcc",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/build/mac/gmake/"
+        ]
+      }
     }
   },
   "windows": {
@@ -23,6 +37,13 @@
         "args": [
           "/d",
           "/c"
+        ]
+      },
+      "problemMatcher": {
+        "base": "$gcc",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/build/windows/gmake/"
         ]
       }
     }
@@ -45,9 +66,7 @@
         "Build [name] (profile)",
         "Build [name] (release)"
       ],
-      "problemMatcher": [
-        "$gcc"
-      ]
+      "problemMatcher": "$gcc"
     },
     {
       "label": "Build [name] (debug)",
@@ -63,10 +82,7 @@
       },
       "windows": {
         "command": "mingw32-make.exe -j config=debug64"
-      },
-      "problemMatcher": [
-        "$gcc"
-      ]
+      }
     },
     {
       "label": "Build [name] (profile)",
@@ -80,10 +96,7 @@
       },
       "windows": {
         "command": "mingw32-make.exe -j config=profile64"
-      },
-      "problemMatcher": [
-        "$gcc"
-      ]
+      }
     },
     {
       "label": "Build [name] (release)",
@@ -97,10 +110,7 @@
       },
       "windows": {
         "command": "mingw32-make.exe -j config=release64"
-      },
-      "problemMatcher": [
-        "$gcc"
-      ]
+      }
     },
     {
       "label": "Run [name] (debug)",

--- a/code/build/template/.vscode/tasks.json
+++ b/code/build/template/.vscode/tasks.json
@@ -124,7 +124,7 @@
       "type": "process",
       "command": "[name]d",
       "options": {
-        "cwd": "bin/"
+        "cwd": "${workspaceFolder}/bin/"
       }
     },
     {
@@ -139,7 +139,7 @@
       "type": "process",
       "command": "[name]",
       "options": {
-        "cwd": "bin/"
+        "cwd": "${workspaceFolder}/bin/"
       }
     },
     {
@@ -154,7 +154,7 @@
       "type": "process",
       "command": "[name]p",
       "options": {
-        "cwd": "bin/"
+        "cwd": "${workspaceFolder}/bin/"
       }
     }
   ]


### PR DESCRIPTION
This PR updates vscode support in the orx repo to be more complete in supporting vscode with its C/C++ extension:

- Configuration for intellisense using gcc (Windows, Linux) or clang (macOS) configuration in orx and in projects created with `init`
- Configuration for debugging with gdb (Windows, Linux), lldb (macOS) in projects created with `init`
- Configuration to run and debug the bounce demo in the orx repo