### PR TITLE
Bumped versions for SDK, NDK, AGP and Gradle.

### DIFF
--- a/code/build/android/build.gradle
+++ b/code/build/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.5.2' apply false
+    id 'com.android.library' version '8.7.1' apply false
 }

--- a/code/build/android/gradle.properties
+++ b/code/build/android/gradle.properties
@@ -21,6 +21,6 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 
 # Specifies the target SDK version, which should always be the latest version available.
-sdkVersion=34
+sdkVersion=35
 
 org.gradle.warning.mode=all

--- a/code/build/android/gradle/wrapper/gradle-wrapper.properties
+++ b/code/build/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Wed Oct 16 20:18:39 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -9,7 +9,7 @@ android {
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.0.12077973'
+    ndkVersion '27.1.12297006'
 
     buildFeatures {
         prefab true

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.0.12077973'
+    ndkVersion '27.1.12297006'
 
     buildFeatures.prefab true
 

--- a/code/demo/android/build.gradle
+++ b/code/demo/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.5.2' apply false
+    id 'com.android.library' version '8.7.1' apply false
 }

--- a/code/demo/android/gradle.properties
+++ b/code/demo/android/gradle.properties
@@ -23,4 +23,4 @@
 android.useAndroidX=true
 
 # Specifies the target SDK version, which should always be the latest version available.
-sdkVersion=34
+sdkVersion=35

--- a/code/demo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/code/demo/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Nothing special, but targeting the latest `SDK 35` is probably a good idea in general.