### PR TITLE
Implement @hcarty's Run windows projects fix

### DIFF
--- a/code/build/template/.vscode/tasks.json
+++ b/code/build/template/.vscode/tasks.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0",
   "presentation": {
-    "reveal": "silent",
+    "reveal": "always",
     "revealProblems": "onProblem"
   },
   "type": "shell",
@@ -123,6 +123,9 @@
       },
       "type": "process",
       "command": "[name]d",
+      "windows": {
+        "command": "[name]d.exe"
+      },
       "options": {
         "cwd": "${workspaceFolder}/bin/"
       }
@@ -138,6 +141,9 @@
       },
       "type": "process",
       "command": "[name]",
+      "windows": {
+        "command": "[name].exe"
+      },
       "options": {
         "cwd": "${workspaceFolder}/bin/"
       }
@@ -153,6 +159,9 @@
       },
       "type": "process",
       "command": "[name]p",
+      "windows": {
+        "command": "[name]p.exe"
+      },
       "options": {
         "cwd": "${workspaceFolder}/bin/"
       }


### PR DESCRIPTION
Also includes opening the task panel on any build or run task for developer feedback.