### PR TITLE
Fixed rare refresh rate issue on Android

### DIFF
--- a/code/build/android/build.gradle
+++ b/code/build/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.7.1' apply false
+    id 'com.android.library' version '8.7.2' apply false
 }

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.22"))
 
-    api 'androidx.core:core:1.13.1'
+    api 'androidx.core:core:1.15.0'
     api 'androidx.appcompat:appcompat:1.7.0'
 
     api 'androidx.games:games-activity:3.0.5'

--- a/code/demo/android/build.gradle
+++ b/code/demo/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.7.1' apply false
+    id 'com.android.library' version '8.7.2' apply false
 }

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -635,8 +635,8 @@ static orxU32 orxAndroid_Display_GetRefreshRate()
   }
   else
   {
-    /* Use default refresh rate */
-    u32Result = orxDISPLAY_KU32_DEFAULT_REFRESH_RATE;
+    /* Use system refresh rate */
+    u32Result = sstDisplay.u32SystemRefreshRate;
   }
 
   /* Done! */

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -503,19 +503,25 @@ static void orxAndroid_HandleGameInput(struct android_app *_pstApp)
           }
           case AMOTION_EVENT_ACTION_DOWN:
           {
-            stPayload.stTouch.u32ID = event->pointers[0].id;
-            stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, 0);
-            stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, 0);
-            orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_BEGIN, orxNULL, orxNULL, &stPayload);
+            for(iIndex = 0; iIndex < event->pointerCount; iIndex++)
+            {
+              stPayload.stTouch.u32ID = event->pointers[iIndex].id;
+              stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, iIndex);
+              stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, iIndex);
+              orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_BEGIN, orxNULL, orxNULL, &stPayload);
+            }
             break;
           }
           case AMOTION_EVENT_ACTION_UP:
           case AMOTION_EVENT_ACTION_CANCEL:
           {
-            stPayload.stTouch.u32ID = event->pointers[0].id;
-            stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, 0);
-            stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, 0);
-            orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_END, orxNULL, orxNULL, &stPayload);
+            for(iIndex = 0; iIndex < event->pointerCount; iIndex++)
+            {
+              stPayload.stTouch.u32ID = event->pointers[iIndex].id;
+              stPayload.stTouch.fX = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_X(event, iIndex);
+              stPayload.stTouch.fY = sstAndroid.fSurfaceScale * orxANDROID_GET_AXIS_Y(event, iIndex);
+              orxEVENT_SEND(orxEVENT_TYPE_SYSTEM, orxSYSTEM_EVENT_TOUCH_END, orxNULL, orxNULL, &stPayload);
+            }
             break;
           }
           case AMOTION_EVENT_ACTION_MOVE:


### PR DESCRIPTION
On my `Pixel 6` (running at 60-90 Hz), my game will occasionally slow down like 30-50%. The steps to reproduce are:
1. Install the game and start it.
2. Swipe away from it.
3. Watch the news for 20 minutes.
4. Return to the game.

**Technical analysis**
Now, on my device, the system refresh rate reported by `Swappy` is always `45`, `60` or `90`. Visually, I cannot see the difference. The game is smooth for all of these reported values. With this in mind, my theory is that we get a discrepancy between the actual frame rate and the frame rate used to set the [display ticks](https://github.com/orx/orx/blob/b616fcf4e85bdfc7aa23af3760d2a1a836468e28/code/src/core/orxClock.c#L295).

First `Init`:
1. Supported refresh rates are populated up to system refresh rate of `X`.
2. _Desired_ refresh rate is set to system refresh rate of `X`.
3. Refresh rate is set to `X`, since `X` is indeed among the supported rates.
4. `X` is saved to `RefreshRate` in config.

My guess is that `X == 90` the first time, as the device is likely running at full speed.

Second `Init` (after `Exit`):
1. Supported refresh rates are populated up to system refresh rate of `Y`.
2. _Desired_ refresh rate `X == 90` is read from config.
3. **The bug:** Refresh rate is set to 60 (default), since `X == 90` is **not** among the supported rates.

My guess is that `Y == 45` the second time, as the device has likely slowed down.

Thus, we set a video mode (clock speed) of 60 Hz whereas the screen runs at 45 Hz, which explains the perceived slow-down of the game.

With this fix, I am not able to reproduce the slow-down.