### PR TITLE
Supported refresh rates on Android are now limited to 240

### DIFF
--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -585,11 +585,6 @@ static void orxAndroid_Display_InitSupportedRefreshRates()
     for(i = 0; i < u32NativeRateCount; i++)
     {
       orxU32 u32RefreshRate = orxDISPLAY_NANO_INVERSE(pu64RefreshPeriods[i]);
-      if(u32RefreshRate > sstDisplay.u32SystemRefreshRate)
-      {
-        /* Current system refresh rate sets the limit */
-        continue;
-      }
 
       for(d = 1; d <= u32RefreshRate; d++)
       {


### PR DESCRIPTION
Previously, the rates were limited to the current system refresh rate. That proved to be problematic since that rate might change during startup.

E.g.:
1. We get a system refresh rate of 45
2. Supported refresh rates are populated up to 45
3. System refresh rate accelerates to 90

Since 90 is "not supported", we revert to 45 and get a lower fps.