### PR TITLE
Android refresh rate handling improved

### DIFF
--- a/code/include/main/android/orxAndroid.h
+++ b/code/include/main/android/orxAndroid.h
@@ -104,14 +104,19 @@ typedef struct __orxANDROID_EVENT_PAYLOAD_t
 ANativeWindow *orxAndroid_GetNativeWindow();
 
 /**
-  Get the internal storage path
+  Gets the internal storage path
   */
 const char *orxAndroid_GetInternalStoragePath();
 
 /**
-  Get the orientation
+  Gets the orientation
   */
 orxU32 orxAndroid_JNI_GetRotation();
+
+/**
+  Gets the physical frame rate
+  */
+orxFLOAT orxAndroid_JNI_GetPhysicalFrameRate();
 
 /**
   Register APK resources IO

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -665,37 +665,27 @@ static orxU32 orxAndroid_Display_GetRefreshRate()
   return u32Result;
 }
 
-static void orxAndroid_Display_UpdateRefreshRate()
+static void orxAndroid_Display_InitializeVideo()
 {
-  orxU32 u32RefreshRate;
+  /* Stores physical refresh rate */
+  sstDisplay.u32PhysicalRefreshRate = orxAndroid_Display_GetPhysicalRefreshRate();
 
-  u32RefreshRate = orxAndroid_Display_GetPhysicalRefreshRate();
-  if(u32RefreshRate != sstDisplay.u32PhysicalRefreshRate)
-  {
-    /* Stores physical refresh rate */
-    sstDisplay.u32PhysicalRefreshRate = u32RefreshRate;
+  /* Re-inits supported refresh rates */
+  orxAndroid_Display_InitSupportedRefreshRates();
 
-    /* Re-inits supported refresh rates */
-    orxAndroid_Display_InitSupportedRefreshRates();
+  sstDisplay.u32RefreshRate = orxAndroid_Display_GetRefreshRate();
 
-    u32RefreshRate = orxAndroid_Display_GetRefreshRate();
+  orxDISPLAY_VIDEO_MODE stVideoMode;
 
-    /* Refresh rate changed? */
-    if(u32RefreshRate != sstDisplay.u32RefreshRate)
-    {
-      orxDISPLAY_VIDEO_MODE stVideoMode;
+  /* Inits video mode */
+  stVideoMode.u32Width        = orxF2U(sstDisplay.pstScreen->fWidth);
+  stVideoMode.u32Height       = orxF2U(sstDisplay.pstScreen->fHeight);
+  stVideoMode.u32RefreshRate  = sstDisplay.u32RefreshRate;
+  stVideoMode.u32Depth        = sstDisplay.u32Depth;
+  stVideoMode.bFullScreen     = orxTRUE;
 
-      /* Inits video mode */
-      stVideoMode.u32Width        = orxF2U(sstDisplay.pstScreen->fWidth);
-      stVideoMode.u32Height       = orxF2U(sstDisplay.pstScreen->fHeight);
-      stVideoMode.u32RefreshRate  = u32RefreshRate;
-      stVideoMode.u32Depth        = sstDisplay.u32Depth;
-      stVideoMode.bFullScreen     = orxTRUE;
-
-      /* Applies it */
-      orxDisplay_Android_SetVideoMode(&stVideoMode);
-    }
-  }
+  /* Applies it */
+  orxDisplay_Android_SetVideoMode(&stVideoMode);
 }
 
 static orxSTATUS orxAndroid_Display_CreateSurface()
@@ -4382,10 +4372,7 @@ static orxSTATUS orxFASTCALL orxDisplay_Android_EventHandler(const orxEVENT *_ps
     }
     else if(_pstEvent->eID == orxANDROID_EVENT_SURFACE_CREATE)
     {
-      orxAndroid_Display_CreateSurface();
-
-      /* Re-inits refresh rate */
-      orxAndroid_Display_UpdateRefreshRate();
+      orxAndroid_Display_InitializeVideo();
     }
     else if(_pstEvent->eID == orxANDROID_EVENT_SURFACE_CHANGE)
     {

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -344,8 +344,8 @@ typedef struct __orxDISPLAY_STATIC_t
   orxU32                    u32Flags;
   orxU32                    u32Depth;
   orxU32                    u32RefreshRate;
-  orxU32                    u32SystemRefreshRate;
-  orxU32                    u32DesiredRefreshRate;
+  orxU32                    u32PhysicalRefreshRate;
+  orxU32                    u32TargetRefreshRate;
   orxS32                    s32ActiveTextureUnit;
   stbi_io_callbacks         stSTBICallbacks;
   GLenum                    aeDrawBufferList[orxDISPLAY_KU32_MAX_TEXTURE_UNIT_NUMBER];
@@ -560,6 +560,24 @@ static orxU32 orxAndroid_Display_GetActiveRefreshRate()
   return u32Result;
 }
 
+static orxU32 orxAndroid_Display_GetPhysicalRefreshRate()
+{
+  orxU32 u32Result, u32Rate;
+
+  u32Rate = (orxU32)orxAndroid_JNI_GetPhysicalFrameRate();
+  if(u32Rate != 0)
+  {
+    u32Result = u32Rate;
+  }
+  else
+  {
+    /* No physical refresh rate? 60 Hz is our best guess! */
+    u32Result = orxDISPLAY_KU32_DEFAULT_REFRESH_RATE;
+  }
+
+  return u32Result;
+}
+
 static void orxAndroid_Display_InitSupportedRefreshRates()
 {
   orxU32 u32NativeRateCount;
@@ -568,9 +586,10 @@ static void orxAndroid_Display_InitSupportedRefreshRates()
   orxMemory_Zero(sstDisplay.acSupportedRates, sizeof(sstDisplay.acSupportedRates) * sizeof(char));
 
   u32NativeRateCount = SwappyGL_getSupportedRefreshPeriodsNS(nullptr, 0);
+
   /* Checks */
   orxASSERT(u32NativeRateCount > 0);
-  orxASSERT(sstDisplay.u32SystemRefreshRate > 0);
+  orxASSERT(sstDisplay.u32PhysicalRefreshRate > 0);
 
   if(u32NativeRateCount > 0)
   {
@@ -585,6 +604,11 @@ static void orxAndroid_Display_InitSupportedRefreshRates()
     for(i = 0; i < u32NativeRateCount; i++)
     {
       orxU32 u32RefreshRate = orxDISPLAY_NANO_INVERSE(pu64RefreshPeriods[i]);
+      if(u32RefreshRate > sstDisplay.u32PhysicalRefreshRate)
+      {
+        /* Current physical refresh rate sets the limit */
+        continue;
+      }
 
       for(d = 1; d <= u32RefreshRate; d++)
       {
@@ -611,12 +635,15 @@ static orxU32 orxAndroid_Display_GetRefreshRate()
 {
   orxU32 u32Result, u32Rate;
 
+  /* Checks */
+  orxASSERT(sstDisplay.u32TargetRefreshRate > 0);
+
   /* Finds best matching refresh rate */
   for(u32Rate = orxDISPLAY_KU32_MAX_REFRESH_RATE; u32Rate > 0; u32Rate--)
   {
     if(orxDISPLAY_BIT_TEST(sstDisplay.acSupportedRates, u32Rate))
     {
-      if(u32Rate <= sstDisplay.u32DesiredRefreshRate)
+      if(u32Rate <= sstDisplay.u32TargetRefreshRate)
       {
         break;
       }
@@ -631,7 +658,7 @@ static orxU32 orxAndroid_Display_GetRefreshRate()
   else
   {
     /* Use system refresh rate */
-    u32Result = sstDisplay.u32SystemRefreshRate;
+    u32Result = orxAndroid_Display_GetActiveRefreshRate();
   }
 
   /* Done! */
@@ -642,27 +669,32 @@ static void orxAndroid_Display_UpdateRefreshRate()
 {
   orxU32 u32RefreshRate;
 
-  /* Stores system refresh rate */
-  sstDisplay.u32SystemRefreshRate = orxAndroid_Display_GetActiveRefreshRate();
-
-  /* Re-inits supported refresh rates */
-  orxAndroid_Display_InitSupportedRefreshRates();
-
-  u32RefreshRate = orxAndroid_Display_GetRefreshRate();
-  /* Refresh rate changed? */
-  if(u32RefreshRate != sstDisplay.u32RefreshRate)
+  u32RefreshRate = orxAndroid_Display_GetPhysicalRefreshRate();
+  if(u32RefreshRate != sstDisplay.u32PhysicalRefreshRate)
   {
-    orxDISPLAY_VIDEO_MODE stVideoMode;
+    /* Stores physical refresh rate */
+    sstDisplay.u32PhysicalRefreshRate = u32RefreshRate;
 
-    /* Inits video mode */
-    stVideoMode.u32Width        = orxF2U(sstDisplay.pstScreen->fWidth);
-    stVideoMode.u32Height       = orxF2U(sstDisplay.pstScreen->fHeight);
-    stVideoMode.u32RefreshRate  = u32RefreshRate;
-    stVideoMode.u32Depth        = sstDisplay.u32Depth;
-    stVideoMode.bFullScreen     = orxTRUE;
+    /* Re-inits supported refresh rates */
+    orxAndroid_Display_InitSupportedRefreshRates();
 
-    /* Applies it */
-    orxDisplay_Android_SetVideoMode(&stVideoMode);
+    u32RefreshRate = orxAndroid_Display_GetRefreshRate();
+
+    /* Refresh rate changed? */
+    if(u32RefreshRate != sstDisplay.u32RefreshRate)
+    {
+      orxDISPLAY_VIDEO_MODE stVideoMode;
+
+      /* Inits video mode */
+      stVideoMode.u32Width        = orxF2U(sstDisplay.pstScreen->fWidth);
+      stVideoMode.u32Height       = orxF2U(sstDisplay.pstScreen->fHeight);
+      stVideoMode.u32RefreshRate  = u32RefreshRate;
+      stVideoMode.u32Depth        = sstDisplay.u32Depth;
+      stVideoMode.bFullScreen     = orxTRUE;
+
+      /* Applies it */
+      orxDisplay_Android_SetVideoMode(&stVideoMode);
+    }
   }
 }
 
@@ -4458,15 +4490,15 @@ orxSTATUS orxFASTCALL orxDisplay_Android_Init()
       sstDisplay.eLastBufferMode    = orxDISPLAY_BUFFER_MODE_NUMBER;
       sstDisplay.ePrimitive         = orxDISPLAY_KE_DEFAULT_PRIMITIVE;
 
-      /* Stores system refresh rate */
-      sstDisplay.u32SystemRefreshRate = orxAndroid_Display_GetActiveRefreshRate();
+      /* Stores physical refresh rate */
+      sstDisplay.u32PhysicalRefreshRate = orxAndroid_Display_GetPhysicalRefreshRate();
 
       /* Inits supported refresh rates */
       orxAndroid_Display_InitSupportedRefreshRates();
 
-      /* Stores depth & refresh rate */
+      /* Stores depth & target refresh rate */
       sstDisplay.u32Depth = orxConfig_HasValue(orxDISPLAY_KZ_CONFIG_DEPTH) ? orxConfig_GetU32(orxDISPLAY_KZ_CONFIG_DEPTH) : 32;
-      sstDisplay.u32DesiredRefreshRate = orxConfig_HasValue(orxDISPLAY_KZ_CONFIG_REFRESH_RATE) ? orxConfig_GetU32(orxDISPLAY_KZ_CONFIG_REFRESH_RATE) : sstDisplay.u32SystemRefreshRate;
+      sstDisplay.u32TargetRefreshRate = orxConfig_HasValue(orxDISPLAY_KZ_CONFIG_REFRESH_RATE) ? orxConfig_GetU32(orxDISPLAY_KZ_CONFIG_REFRESH_RATE) : orxAndroid_Display_GetActiveRefreshRate();
 
       /* Inits refresh rate */
       sstDisplay.u32RefreshRate = orxAndroid_Display_GetRefreshRate();

--- a/code/src/main/android/orxAndroidSupport.cpp
+++ b/code/src/main/android/orxAndroidSupport.cpp
@@ -334,6 +334,41 @@ extern "C" orxU32 orxAndroid_JNI_GetRotation()
   return rotation;
 }
 
+extern "C" orxFLOAT orxAndroid_JNI_GetPhysicalFrameRate()
+{
+  orxFLOAT fRefreshRate;
+
+  /* Note : Display.Mode.getRefreshRate() returns the physical refresh rate starting with Android S */
+  if(orxAndroid_GetSdkVersion() < __ANDROID_API_S__)
+  {
+    return orxFLOAT_0;
+  }
+
+  JNIEnv *pstEnv = orxAndroid_JNI_GetEnv();
+
+  pstEnv->PushLocalFrame(16);
+
+  /* Gets display structure */
+  jobject display = orxAndroid_JNI_getDisplay(pstEnv);
+
+  /* Finds classes */
+  jclass displayClass = pstEnv->FindClass("android/view/Display");
+  jclass modeClass = pstEnv->FindClass("android/view/Display$Mode");
+
+  /* Finds methods */
+  jmethodID getModeMethod = pstEnv->GetMethodID(displayClass, "getMode", "()Landroid/view/Display$Mode;");
+  jmethodID getRefreshRateMethod = pstEnv->GetMethodID(modeClass, "getRefreshRate", "()F");
+
+  /* Calls method and stores refresh rate */
+  jobject mode = pstEnv->CallObjectMethod(display, getModeMethod);
+  fRefreshRate = float(pstEnv->CallFloatMethod(mode, getRefreshRateMethod));
+
+  /* Frees all the local references */
+  pstEnv->PopLocalFrame(NULL);
+
+  return fRefreshRate;
+}
+
 extern "C" void orxAndroid_SetKeyFilter(android_key_event_filter _pfnFilter)
 {
   android_app_set_key_event_filter(sstAndroid.app, _pfnFilter);


### PR DESCRIPTION
This PR aims to _reduce_ the likelihood of getting reduced game speed after semi-complete system gestures on Pixel 6. See [Google issue 377528725](https://issuetracker.google.com/issues/377528725).

We no longer keep track of the app refresh rate (since it can change at anytime). Instead, we query the physical refresh rate. This change has proven to be more stable on the following devices:
* Pixel 6
* Lenovo P12 Pro

My conclusions so far are:
a) Pixel 6 has bad OpenGL drivers. Switching to vulkan (Google sample) eliminates the slow-down glitch.
b) Swappy works mainly with app refresh rates whereas we have a clock dependency on the physical refresh rate. (Maybe not the physical refresh rate per se, but the actual toggling of the display setting itself.)