### PR TITLE
Rare crash in Android Display plugin

### DIFF
--- a/code/build/android/build.gradle
+++ b/code/build/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.7.2' apply false
+    id 'com.android.library' version '8.7.3' apply false
 }

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -9,7 +9,7 @@ android {
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.1.12297006'
+    ndkVersion '27.2.12479018'
 
     buildFeatures {
         prefab true

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.1.12297006'
+    ndkVersion '27.2.12479018'
 
     buildFeatures.prefab true
 

--- a/code/demo/android/build.gradle
+++ b/code/demo/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.7.2' apply false
+    id 'com.android.library' version '8.7.3' apply false
 }

--- a/code/plugins/Display/android/orxDisplay.c
+++ b/code/plugins/Display/android/orxDisplay.c
@@ -3079,16 +3079,20 @@ orxSTATUS orxFASTCALL orxDisplay_Android_Swap()
   /* Draws remaining items */
   orxDisplay_Android_DrawArrays();
 
-  /* Swaps buffers */
-  if(sstDisplay.bSwappyEnabled)
+  /* Has valid surface? */
+  if(sstDisplay.surface != EGL_NO_SURFACE)
   {
-    SwappyGL_swap(sstDisplay.display, sstDisplay.surface);
+    /* Swaps buffers */
+    if(sstDisplay.bSwappyEnabled)
+    {
+      SwappyGL_swap(sstDisplay.display, sstDisplay.surface);
+    }
+    else
+    {
+      eglSwapBuffers(sstDisplay.display, sstDisplay.surface);
+    }
+    eglASSERT();
   }
-  else
-  {
-    eglSwapBuffers(sstDisplay.display, sstDisplay.surface);
-  }
-  eglASSERT();
 
   /* Done! */
   return eResult;


### PR DESCRIPTION
Fixes a rare crash in Android Display plugin where `eglSwapBuffers()` would fail for an invalid surface and subsequently assert. Also bumped some versions.

The symptoms of this crash may vary, but the game would usually exit immediately when resumed after some hours of sleep. There is a good chance that this also fixes the crash seen in `miniaudio` (see https://github.com/mackron/miniaudio/issues/913). We'll see!

**Steps to reproduce** (before fix)
1. Debug the `orxDemo` game.
2. Put breakpoints at `miniaudio.h(38110)` and `miniaudio.h(38364)`.
3. Swipe away from the game.
4. Change audio device by enabling e.g. bluetooth earpods.
5. Wait until first breakpoint is hit. Continue debugging.
6. Crash!

`Miniaudio` seems to crash in `ma_open_stream_and_close_builder__aaudio()` when opening the newly created stream, but at the same time our main thread ends up in `_orxDebug_Break()` due to the aformentioned assert. It's unclear exactly what happens at this point, but... the app crashes! 💁