### PR TITLE
Android updates

### DIFF
--- a/code/build/android/build.gradle
+++ b/code/build/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.9.0' apply false
+    id 'com.android.library' version '8.12.0' apply false
 }

--- a/code/build/android/gradle.properties
+++ b/code/build/android/gradle.properties
@@ -21,6 +21,6 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 
 # Specifies the target SDK version, which should always be the latest version available.
-sdkVersion=35
+sdkVersion=36
 
 org.gradle.warning.mode=all

--- a/code/build/android/gradle/wrapper/gradle-wrapper.properties
+++ b/code/build/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sun Mar 09 18:21:52 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -4,16 +4,16 @@ plugins {
 }
 
 android {
-    namespace 'org.orx.lib'
+    namespace = 'org.orx.lib'
     compileSdk = sdkVersion.toInteger()
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.3.13750724'
+    ndkVersion = '27.3.13750724'
 
     buildFeatures {
-        prefab true
-        prefabPublishing true
+        prefab = true
+        prefabPublishing = true
     }
 
     defaultConfig {
@@ -33,13 +33,13 @@ android {
     }
     prefab {
         orx {
-            headers "${System.env.ORX}/include"
+            headers = "${System.env.ORX}/include"
         }
         webpdecoder_static {
-            headers "${System.env.ORX}/../extern/libwebp/src"
+            headers = "${System.env.ORX}/../extern/libwebp/src"
         }
         liquidfun_static {
-            headers "${System.env.ORX}/../extern/LiquidFun-1.1.0/include"
+            headers = "${System.env.ORX}/../extern/LiquidFun-1.1.0/include"
         }
     }
     packagingOptions {
@@ -84,7 +84,7 @@ android {
         }
     }
     lint {
-        abortOnError true
+        abortOnError = true
     }
 }
 dependencies {
@@ -104,27 +104,27 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId 'org.orx-project'
-                artifactId 'orx'
-                version android.defaultConfig.versionName
+                groupId = 'org.orx-project'
+                artifactId = 'orx'
+                version = android.defaultConfig.versionName
             }
             debug(MavenPublication) {
                 from components.debug
-                groupId 'org.orx-project'
-                artifactId 'orxd'
-                version android.defaultConfig.versionName
+                groupId = 'org.orx-project'
+                artifactId = 'orxd'
+                version = android.defaultConfig.versionName
             }
             profile(MavenPublication) {
                 from components.profile
-                groupId 'org.orx-project'
-                artifactId 'orxp'
-                version android.defaultConfig.versionName
+                groupId = 'org.orx-project'
+                artifactId = 'orxp'
+                version = android.defaultConfig.versionName
             }
         }
         repositories {
             maven {
                 name = 'orx'
-                url "${System.env.ORX}/lib/static/android/repository/"
+                url = "${System.env.ORX}/lib/static/android/repository/"
             }
         }
     }

--- a/code/build/android/orx/build.gradle
+++ b/code/build/android/orx/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'org.orx.lib'
-    compileSdk sdkVersion.toInteger()
+    compileSdk = sdkVersion.toInteger()
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.2.12479018'
+    ndkVersion '27.3.13750724'
 
     buildFeatures {
         prefab true
@@ -91,12 +91,12 @@ dependencies {
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.22"))
 
-    api 'androidx.core:core:1.15.0'
-    api 'androidx.appcompat:appcompat:1.7.0'
+    api 'androidx.core:core:1.17.0'
+    api 'androidx.appcompat:appcompat:1.7.1'
 
-    api 'androidx.games:games-activity:4.0.0'
-    api 'androidx.games:games-controller:2.0.2'
-    api 'androidx.games:games-frame-pacing:2.1.2'
+    api 'androidx.games:games-activity:4.3.0-alpha01'
+    api 'androidx.games:games-controller:2.3.0-alpha01'
+    api 'androidx.games:games-frame-pacing:2.3.0-alpha01'
 }
 
 afterEvaluate {

--- a/code/build/android/orx/src/main/java/org/orx/lib/OrxGameActivity.java
+++ b/code/build/android/orx/src/main/java/org/orx/lib/OrxGameActivity.java
@@ -1,8 +1,5 @@
 package org.orx.lib;
 
-import android.view.View;
-
-import androidx.annotation.NonNull;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
@@ -13,17 +10,6 @@ public class OrxGameActivity extends GameActivity {
     protected void onResume() {
         super.onResume();
         hideSystemBars();
-    }
-
-    @NonNull
-    @Override
-    public WindowInsetsCompat onApplyWindowInsets(View v, WindowInsetsCompat insets) {
-        // See https://issuetracker.google.com/issues/398193010
-        if (mDestroyed) {
-            return insets;
-        }
-
-        return super.onApplyWindowInsets(v, insets);
     }
 
     protected void hideSystemBars() {

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 
 android {
     namespace 'org.orx.demo'
-    compileSdk sdkVersion.toInteger()
+    compileSdk = sdkVersion.toInteger()
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.2.12479018'
+    ndkVersion '27.3.13750724'
 
     buildFeatures.prefab true
 

--- a/code/demo/android/app/build.gradle
+++ b/code/demo/android/app/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace 'org.orx.demo'
+    namespace = 'org.orx.demo'
     compileSdk = sdkVersion.toInteger()
 
     // Ideally, we want to use the default NDK version for the used AGP version.
     // However, we opt-in to NDK r27 since it comes with many important features/optimizations.
-    ndkVersion '27.3.13750724'
+    ndkVersion = '27.3.13750724'
 
-    buildFeatures.prefab true
+    buildFeatures.prefab = true
 
     defaultConfig {
         applicationId 'org.orx.demo'
@@ -69,7 +69,7 @@ android {
         }
     }
     lint {
-        abortOnError true
+        abortOnError = true
     }
     androidResources {
         noCompress = [ '.obr', '.ktx2' ]

--- a/code/demo/android/build.gradle
+++ b/code/demo/android/build.gradle
@@ -1,4 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.9.0' apply false
+    id 'com.android.library' version '8.12.0' apply false
 }

--- a/code/demo/android/gradle.properties
+++ b/code/demo/android/gradle.properties
@@ -23,4 +23,4 @@
 android.useAndroidX=true
 
 # Specifies the target SDK version, which should always be the latest version available.
-sdkVersion=35
+sdkVersion=36

--- a/code/demo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/code/demo/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sun Mar 09 18:21:52 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/code/demo/android/settings.gradle
+++ b/code/demo/android/settings.gradle
@@ -9,7 +9,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         maven {
-            url "${System.env.ORX}/lib/static/android/repository/"
+            url = "${System.env.ORX}/lib/static/android/repository/"
         }
 
         google()


### PR DESCRIPTION
Updated AGDK libraries to `4.3.0-alpha01`. I have monitored the commits for months, and this version finally fixes all known annoyances of `GameActivity` and its associated libraries.

**Touch handling improved**
* Touch in split screen finally works. You can play `orx Demo` and chat with your favorit chatbot at the same time!
* Workaround for missing "touch end" events no longer needed. Verified on the device where the issue was originally identified.

**Stability improved**
* Workaround for activity life-cycle related crashes no longer needed.

**Version bumps**
* SDK 36
* Latest NDK r27
* Latest Gradle etc. Fixed all deprecation warnings.