### PR TITLE
fix: setting indent to tab for Makefiles in editorconfig

### DIFF
--- a/code/build/template/[=].editorconfig
+++ b/code/build/template/[=].editorconfig
@@ -10,5 +10,8 @@ charset                   = utf-8
 trim_trailing_whitespace  = true
 insert_final_newline      = true
 
+[Makefile]
+indent_style              = tab
+
 [*.lua]
 indent_size               = 4


### PR DESCRIPTION
Hi,

This is a very trivial change.

Previously editors that fully honor `.editorconfig` rules would use spaces for indentation in Makefiles. However, Makefiles do not allow that.

This simply introduces a special case for Makefiles to indent with tabs.